### PR TITLE
fix: host exposure rollout — verify tooling hardening + guidance (R1 closure)

### DIFF
--- a/patches/README.md
+++ b/patches/README.md
@@ -46,9 +46,32 @@ The patch adds `'advisor'` (and mentions the advisor section in the comment):
 ```
 
 That is the entire change: a one-element allowlist addition with no behavior
-change elsewhere. After it is applied (and the host rebuilt), the web Settings
-page can read and write the `advisor` namespace, and the Advisor section's
-Apply round-trip works against the real host.
+change elsewhere. After it is applied and the running host is restarted (see
+[Runtime shape](#runtime-shape) below), the web Settings page can read and
+write the `advisor` namespace, and the Advisor section's Apply round-trip
+works against the real host.
+
+## Runtime shape
+
+The standard staged install runs the dsh CLI from a **snapshot**
+(`$DSH_HOME/source/current`) whose `dsh` launcher executes the CLI **from
+TypeScript source via tsx**, using the snapshot's own `tsconfig` paths —
+`@deepseek-ai/dsh-host-apiproxy` resolves to `packages/host/apiproxy/src`
+(not `lib/`). Consequences for this patch:
+
+- The **source probe** (`src/api-proxy.ts`) is the runtime-relevant one:
+  `git apply` alone makes the change effective — no build step is required for
+  the tsx path.
+- The **tsc/tsdown build artifacts** (`lib/types/api-proxy.js`,
+  `lib/index.js`) are for consistency only — they matter for consumers that
+  import the dsh packages outside the tsx-from-source install (e.g. `node`
+  mode).
+- **A restart of the `dsh web` process is required** for the change to load:
+  applying the patch edits files on disk; the running process keeps the old
+  source until restarted. `verify-dsh-patch.sh --runtime` detects exactly this
+  case (file probes pass, runtime probe fails).
+- After a **dsh upgrade** (a new `$DSH_HOME/source/current` staging) the patch
+  must be re-applied — see [Re-run after a dsh upgrade](#re-run-after-a-dsh-upgrade).
 
 ## Relationship to the plugin's Settings section
 
@@ -93,8 +116,9 @@ scripts/revert-dsh-patch.sh --check
 ### Verify
 
 ```sh
-scripts/verify-dsh-patch.sh           # assert the marker is present (source + build artifact)
-scripts/verify-dsh-patch.sh --absent  # assert the marker is absent (after revert)
+scripts/verify-dsh-patch.sh                  # assert the marker is present (source + build artifacts)
+scripts/verify-dsh-patch.sh --absent         # assert the marker is absent (after revert)
+scripts/verify-dsh-patch.sh --runtime [URL]  # assert the RUNNING dsh web server exposes the namespace
 ```
 
 Verify probes (existing files are checked; missing files are recorded as
@@ -104,12 +128,27 @@ SKIP):
   `'ui-onboarding', 'advisor'`
 - build: `packages/host/apiproxy/lib/types/api-proxy.js` contains
   `'ui-onboarding', 'advisor'`
+- bundle: `packages/host/apiproxy/lib/index.js` contains
+  `"ui-onboarding", "advisor"` (the tsdown bundle — the package `main`, the
+  runtime entry for consumers outside the tsx-from-source install; tsdown
+  emits double-quoted string literals, hence the bundle-form marker)
 
 > The constant is module-private, so it never reaches the `.d.ts`; the compiled
-> JS (`lib/types/api-proxy.js`, the tsc emit under `outDir: lib/types`) is the
-> build probe. After `--skip-build` the build probe still holds the stale
-> artifact, so verify only passes once the package is rebuilt — apply without
-> `--skip-build`, or rebuild manually first.
+> JS (`lib/types/api-proxy.js`, the tsc emit under `outDir: lib/types`) and the
+> tsdown bundle (`lib/index.js`) are the build probes. After `--skip-build`
+> these lib probes still hold the stale artifact, so the file verify only
+> passes once the package is rebuilt — apply without `--skip-build`, or rebuild
+> manually first (the source probe and `--runtime` are unaffected).
+
+`--runtime` proves the patch is effective in the **running** server, not just
+in the tree — the file probes cannot detect a server that was not restarted.
+It POSTs `{url}/api/settings.describe` (envelope
+`{"type":"client-request","rpcId":"verify","method":"settings.describe","payload":{}}`,
+10s timeout) and asserts the response namespaces include `advisor` (with
+`--absent`, that they exclude it). The URL defaults to
+`http://127.0.0.1:3080`. The script distinguishes a server-unreachable failure
+(not running / not restarted) from a namespace-not-exposed failure, and exits
+non-zero on either.
 
 ### Install-time autopatch
 

--- a/patches/README.md
+++ b/patches/README.md
@@ -145,13 +145,15 @@ in the tree — the file probes cannot detect a server that was not restarted.
 It POSTs `{url}/api/settings.describe` (envelope
 `{"type":"client-request","rpcId":"verify","method":"settings.describe","payload":{}}`,
 10s timeout) and asserts the response namespaces include `advisor` (with
-`--absent`, that they exclude it). With `--absent`, absence is only asserted
-against a valid `settings.describe` **success envelope** (`"ok":true` with a
-`namespaces` result) — an HTTP error page, an error envelope, or garbage fails
-instead of passing as "absent". The URL defaults to `http://127.0.0.1:3080`
-and may carry one trailing slash (normalized before concatenation). The script
-distinguishes a server-unreachable failure (not running / not restarted) from
-a namespace-not-exposed failure, and exits non-zero on either.
+`--absent`, that they exclude it). Both modes only trust a valid
+`settings.describe` **success envelope** (`"ok":true` with a `namespaces`
+result) — an HTTP error page, an error envelope, or garbage fails instead of
+being read as "absent"/"not exposed". The URL defaults to
+`http://127.0.0.1:3080` and may carry any number of trailing slashes
+(normalized before concatenation). The script distinguishes a server-unreachable
+failure (not running / not restarted) from a namespace-not-exposed failure, and
+exits non-zero on either. The probe is **read-only** (a `settings.describe`
+call) and sends **no credentials**; it bypasses proxies (`curl --noproxy`).
 
 ### Install-time autopatch
 
@@ -170,13 +172,25 @@ DSH_ADVISOR_AUTOPATCH=0 pnpm install
 
 ## Re-run after a dsh upgrade
 
-A dsh upgrade (a new `$DSH_HOME/source/current` staging) **resets** the host
-change: after upgrading, re-run `scripts/apply-dsh-patch.sh` (idempotent —
-skips when already applied) and confirm with `scripts/verify-dsh-patch.sh`. If
-the upgrade moved the context so the patch no longer applies, the script
+A dsh upgrade stages a new `$DSH_HOME/source/current` snapshot. Whether the
+patch needs re-applying depends on where the snapshot came from:
+
+- If the snapshot was staged from a **patched dsh-private tree** (this
+  project's fix flow patches the private tree too, so future snapshots inherit
+  the change), the host change is already present — `scripts/apply-dsh-patch.sh`
+  detects this and skips idempotently (its reverse-apply check passes).
+- If the snapshot is pristine (e.g. pulled from upstream), re-run
+  `scripts/apply-dsh-patch.sh` (idempotent — applies when missing) and confirm
+  the files with `scripts/verify-dsh-patch.sh`.
+
+If the upgrade moved the context so the patch no longer applies, the script
 reports the conflict; the patch may need regenerating against the new source
 lines (the change itself is a one-line allowlist entry, so regeneration is
 trivial).
+
+Either way, file probes passing does not prove the running server has the
+change: after (re-)applying, **restart `dsh web`** and prove the runtime state
+with `scripts/verify-dsh-patch.sh --runtime`.
 
 ## Security note
 

--- a/patches/README.md
+++ b/patches/README.md
@@ -145,10 +145,13 @@ in the tree — the file probes cannot detect a server that was not restarted.
 It POSTs `{url}/api/settings.describe` (envelope
 `{"type":"client-request","rpcId":"verify","method":"settings.describe","payload":{}}`,
 10s timeout) and asserts the response namespaces include `advisor` (with
-`--absent`, that they exclude it). The URL defaults to
-`http://127.0.0.1:3080`. The script distinguishes a server-unreachable failure
-(not running / not restarted) from a namespace-not-exposed failure, and exits
-non-zero on either.
+`--absent`, that they exclude it). With `--absent`, absence is only asserted
+against a valid `settings.describe` **success envelope** (`"ok":true` with a
+`namespaces` result) — an HTTP error page, an error envelope, or garbage fails
+instead of passing as "absent". The URL defaults to `http://127.0.0.1:3080`
+and may carry one trailing slash (normalized before concatenation). The script
+distinguishes a server-unreachable failure (not running / not restarted) from
+a namespace-not-exposed failure, and exits non-zero on either.
 
 ### Install-time autopatch
 

--- a/scripts/apply-dsh-patch.sh
+++ b/scripts/apply-dsh-patch.sh
@@ -11,6 +11,13 @@
 # This script applies that change as a git patch to the dsh source tree (this
 # repo does not ship the dsh source).
 #
+# Runtime shape: in the standard staged install ($DSH_HOME/source/current) the
+# dsh launcher runs the CLI from TypeScript source via tsx (the snapshot's
+# tsconfig paths map @deepseek-ai/dsh-host-apiproxy → packages/host/apiproxy/src),
+# so `git apply` alone is effective at runtime; the build step below only keeps
+# the lib artifacts consistent for non-tsx consumers, and a restart of dsh web
+# is required for the change to load.
+#
 # Target resolution (at runtime; the script itself contains no local absolute paths):
 #   $DSH_SOURCE_DIR (if set) → default ${DSH_HOME}/source/current
 #
@@ -48,7 +55,7 @@ PATCH_FILES=(
 )
 
 usage() {
-  sed -n '2,29p' "$0" | sed 's/^# \{0,1\}//'
+  sed -n '2,36p' "$0" | sed 's/^# \{0,1\}//'
   exit "${1:-0}"
 }
 

--- a/scripts/apply-dsh-patch.sh
+++ b/scripts/apply-dsh-patch.sh
@@ -55,7 +55,7 @@ PATCH_FILES=(
 )
 
 usage() {
-  sed -n '2,36p' "$0" | sed 's/^# \{0,1\}//'
+  sed -n '2,43p' "$0" | sed 's/^# \{0,1\}//'
   exit "${1:-0}"
 }
 

--- a/scripts/verify-dsh-patch.sh
+++ b/scripts/verify-dsh-patch.sh
@@ -23,7 +23,8 @@
 #
 # With --runtime [URL] the script skips the file probes and instead queries a
 # running dsh web server: POST {url}/api/settings.describe and assert the
-# response namespaces include `advisor` (with --absent, that they exclude it).
+# response namespaces include `advisor` (with --absent, that they exclude it —
+# only against a settings.describe success envelope; error pages/envelopes fail).
 # This proves the patch is effective in the RUNNING server — a dsh web restart
 # is required after applying the patch, and file probes alone cannot prove it.
 # URL defaults to http://127.0.0.1:3080.
@@ -43,7 +44,7 @@
 set -euo pipefail
 
 usage() {
-  sed -n '2,42p' "$0" | sed 's/^# \{0,1\}//'
+  sed -n '2,43p' "$0" | sed 's/^# \{0,1\}//'
   exit "${1:-0}"
 }
 
@@ -84,6 +85,10 @@ runtime_probe() {
   local url="$1"
   local body="" curl_status=0 exposed=0
 
+  # Normalize the URL: strip one trailing slash so {url}/api/settings.describe
+  # never becomes {url}//api/settings.describe.
+  url="${url%/}"
+
   # `|| curl_status=$?` (not `if ! ...; then $?`) — inside an `if !` branch $?
   # is the NEGATED status (0), which would mask curl failures.
   body="$(curl --silent --show-error --max-time 10 \
@@ -106,6 +111,16 @@ runtime_probe() {
     if [[ "$exposed" -eq 1 ]]; then
       [[ "$QUIET" -eq 0 ]] && printf '  [FAIL] runtime probe %-36s unexpected namespace\n' "(${url})" >&2
       echo "ERROR: runtime probe failed: ${url} exposes the advisor namespace (expected absent)." >&2
+      exit 1
+    fi
+    # Absent-guard: only declare "advisor absent" when the body is a
+    # settings.describe SUCCESS envelope ("ok":true with a namespaces result).
+    # An HTTP error page, an error envelope (ok:false), or garbage must FAIL
+    # instead of passing as "absent". The present direction needs no guard: a
+    # non-envelope response simply lacks "ns":"advisor" and already fails.
+    if ! grep -qF '"ok":true' <<< "$body" || ! grep -qF '"namespaces"' <<< "$body"; then
+      [[ "$QUIET" -eq 0 ]] && printf '  [FAIL] runtime probe %-36s unexpected response\n' "(${url})" >&2
+      echo "ERROR: runtime probe failed: unexpected response from ${url} (not a settings.describe success envelope) — cannot assert namespace absence." >&2
       exit 1
     fi
     [[ "$QUIET" -eq 0 ]] && printf '  [PASS] runtime probe %-36s advisor namespace absent\n' "(${url})"

--- a/scripts/verify-dsh-patch.sh
+++ b/scripts/verify-dsh-patch.sh
@@ -1,46 +1,72 @@
 #!/usr/bin/env bash
 #
 # verify-dsh-patch.sh — verify the host exposure patch's effect (present / absent)
-# in the target dsh source tree.
+# in the target dsh source tree, or in a running dsh web server (--runtime).
 #
-# Two probes are checked (existing files are checked; missing files are recorded
-# as SKIP and never counted as pass or fail):
+# Three file probes are checked (existing files are checked; missing files are
+# recorded as SKIP and never counted as pass or fail):
 #   @deepseek-ai/dsh-host-apiproxy  src/api-proxy.ts            → expect `'ui-onboarding', 'advisor'`
 #                                   lib/types/api-proxy.js      → expect `'ui-onboarding', 'advisor'`
 #                                   (build artifact; tsc emits outDir lib/types — the
 #                                    constant is module-private and never reaches the
 #                                    .d.ts, so the compiled JS is the build probe)
+#                                   lib/index.js                → expect `"ui-onboarding", "advisor"`
+#                                   (tsdown bundle — the package `main`, the runtime
+#                                    entry when dsh packages are consumed outside the
+#                                    tsx-from-source install; tsdown emits double-quoted
+#                                    string literals, hence the bundle-form marker)
 #
 # By default the marker must be present (patch applied and rebuilt); --absent
 # inverts the assertion (after revert). Verdict: any existing probe that violates
 # the assertion → exit 1; if no probe file exists at all, the tree is not a dsh
 # tree → exit 1.
 #
+# With --runtime [URL] the script skips the file probes and instead queries a
+# running dsh web server: POST {url}/api/settings.describe and assert the
+# response namespaces include `advisor` (with --absent, that they exclude it).
+# This proves the patch is effective in the RUNNING server — a dsh web restart
+# is required after applying the patch, and file probes alone cannot prove it.
+# URL defaults to http://127.0.0.1:3080.
+#
 # Target resolution (at runtime; the script itself contains no local absolute paths):
 #   $DSH_SOURCE_DIR (if set) → default ${DSH_HOME}/source/current
 #
 # Options:
-#   --absent         assert the marker is absent (post-revert verification).
+#   --absent         assert the marker / namespace is absent (post-revert verification).
+#   --runtime [URL]  probe the running dsh web server instead of the tree files
+#                    (URL defaults to http://127.0.0.1:3080; combines with --absent).
 #   -d|--target DIR   target dsh source tree (overrides env resolution).
 #   -q|--quiet       print only the final verdict.
 #   -h|--help        show this help.
 #
-# Exit codes: 0 = verify passed; 1 = verify failed / target unavailable.
+# Exit codes: 0 = verify passed; 1 = verify failed / server unavailable.
 set -euo pipefail
 
 usage() {
-  sed -n '2,24p' "$0" | sed 's/^# \{0,1\}//'
+  sed -n '2,42p' "$0" | sed 's/^# \{0,1\}//'
   exit "${1:-0}"
 }
 
 ABSENT=0
 QUIET=0
 TARGET=""
+RUNTIME=0
+RUNTIME_URL="http://127.0.0.1:3080"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --absent) ABSENT=1; shift ;;
     -q|--quiet) QUIET=1; shift ;;
+    --runtime)
+      RUNTIME=1
+      shift
+      # Optional URL argument (a non-option token only); a bare `--runtime`
+      # keeps the default URL.
+      if [[ $# -gt 0 && -n "$1" && "$1" != -* ]]; then
+        RUNTIME_URL="$1"
+        shift
+      fi
+      ;;
     -d|--target)
       if [[ $# -lt 2 || -z "$2" || "$2" == -* ]]; then
         echo "ERROR: $1 requires a target directory argument" >&2
@@ -51,6 +77,56 @@ while [[ $# -gt 0 ]]; do
     *) echo "unknown option: $1" >&2; usage 1 ;;
   esac
 done
+
+# --runtime mode: probe a running dsh web server instead of the tree files.
+# The probe needs no target directory, so it runs before target resolution.
+runtime_probe() {
+  local url="$1"
+  local body="" curl_status=0 exposed=0
+
+  # `|| curl_status=$?` (not `if ! ...; then $?`) — inside an `if !` branch $?
+  # is the NEGATED status (0), which would mask curl failures.
+  body="$(curl --silent --show-error --max-time 10 \
+      --request POST \
+      --header 'Content-Type: application/json' \
+      --data '{"type":"client-request","rpcId":"verify","method":"settings.describe","payload":{}}' \
+      "${url}/api/settings.describe" 2>&1)" || curl_status=$?
+
+  if [[ "$curl_status" -ne 0 ]]; then
+    [[ "$QUIET" -eq 0 ]] && printf '  [FAIL] runtime probe %-36s server unreachable\n' "(${url})" >&2
+    echo "ERROR: runtime probe failed: cannot reach dsh web at ${url} (server not running, or not restarted after applying the patch): ${body}" >&2
+    exit 1
+  fi
+
+  if grep -qF '"ns":"advisor"' <<< "$body"; then
+    exposed=1
+  fi
+
+  if [[ "$ABSENT" -eq 1 ]]; then
+    if [[ "$exposed" -eq 1 ]]; then
+      [[ "$QUIET" -eq 0 ]] && printf '  [FAIL] runtime probe %-36s unexpected namespace\n' "(${url})" >&2
+      echo "ERROR: runtime probe failed: ${url} exposes the advisor namespace (expected absent)." >&2
+      exit 1
+    fi
+    [[ "$QUIET" -eq 0 ]] && printf '  [PASS] runtime probe %-36s advisor namespace absent\n' "(${url})"
+    echo "== verify passed: runtime namespace 'advisor' absent at ${url}"
+    exit 0
+  fi
+
+  if [[ "$exposed" -eq 0 ]]; then
+    [[ "$QUIET" -eq 0 ]] && printf '  [FAIL] runtime probe %-36s namespace not exposed\n' "(${url})" >&2
+    echo "ERROR: runtime probe failed: ${url} does not expose the advisor namespace (settings.describe response lacks \"ns\":\"advisor\") — the patch is not effective at runtime (server not restarted, or not a dsh web endpoint)." >&2
+    exit 1
+  fi
+
+  [[ "$QUIET" -eq 0 ]] && printf '  [PASS] runtime probe %-36s advisor namespace exposed\n' "(${url})"
+  echo "== verify passed: runtime namespace 'advisor' exposed at ${url}"
+  exit 0
+}
+
+if [[ "$RUNTIME" -eq 1 ]]; then
+  runtime_probe "$RUNTIME_URL"
+fi
 
 # Resolve the target directory
 if [[ -z "$TARGET" ]]; then
@@ -63,9 +139,14 @@ if [[ ! -d "$TARGET" ]]; then
 fi
 
 # Probes: (relative path|fixed string|label)
+# NOTE: the tsdown bundle (lib/index.js) is emitted with double-quoted string
+# literals (rolldown/esbuild quote normalization), so its probe marker is the
+# bundle form `"ui-onboarding", "advisor"` rather than the single-quoted source
+# form that appears in src/ and the tsc emit (lib/types/api-proxy.js).
 PROBES=(
   "packages/host/apiproxy/src/api-proxy.ts|'ui-onboarding', 'advisor'|host-apiproxy source (src/api-proxy.ts)"
   "packages/host/apiproxy/lib/types/api-proxy.js|'ui-onboarding', 'advisor'|host-apiproxy build (lib/types/api-proxy.js)"
+  "packages/host/apiproxy/lib/index.js|\"ui-onboarding\", \"advisor\"|host-apiproxy bundle (lib/index.js)"
 )
 
 EXPECT_LABEL="present"

--- a/scripts/verify-dsh-patch.sh
+++ b/scripts/verify-dsh-patch.sh
@@ -10,11 +10,11 @@
 #                                   (build artifact; tsc emits outDir lib/types — the
 #                                    constant is module-private and never reaches the
 #                                    .d.ts, so the compiled JS is the build probe)
-#                                   lib/index.js                → expect `"ui-onboarding", "advisor"`
+#                                   lib/index.js                → expect PRODUCT_SETTINGS_NAMESPACES … advisor
 #                                   (tsdown bundle — the package `main`, the runtime
 #                                    entry when dsh packages are consumed outside the
-#                                    tsx-from-source install; tsdown emits double-quoted
-#                                    string literals, hence the bundle-form marker)
+#                                    tsx-from-source install; the probe greps the
+#                                    assignment context, quote- and order-agnostic)
 #
 # By default the marker must be present (patch applied and rebuilt); --absent
 # inverts the assertion (after revert). Verdict: any existing probe that violates
@@ -23,11 +23,11 @@
 #
 # With --runtime [URL] the script skips the file probes and instead queries a
 # running dsh web server: POST {url}/api/settings.describe and assert the
-# response namespaces include `advisor` (with --absent, that they exclude it —
-# only against a settings.describe success envelope; error pages/envelopes fail).
-# This proves the patch is effective in the RUNNING server — a dsh web restart
-# is required after applying the patch, and file probes alone cannot prove it.
-# URL defaults to http://127.0.0.1:3080.
+# response namespaces include `advisor` (with --absent, that they exclude it).
+# Both modes only trust a settings.describe SUCCESS envelope; an HTTP error
+# page, error envelope, or garbage fails (server not restarted / wrong endpoint).
+# The probe is read-only, sends no credentials, and bypasses proxies
+# (--noproxy). URL defaults to http://127.0.0.1:3080.
 #
 # Target resolution (at runtime; the script itself contains no local absolute paths):
 #   $DSH_SOURCE_DIR (if set) → default ${DSH_HOME}/source/current
@@ -83,15 +83,23 @@ done
 # The probe needs no target directory, so it runs before target resolution.
 runtime_probe() {
   local url="$1"
-  local body="" curl_status=0 exposed=0
+  local body="" curl_status=0 exposed=0 envelope_ok=0
 
-  # Normalize the URL: strip one trailing slash so {url}/api/settings.describe
+  # Normalize the URL: strip ALL trailing slashes so {url}/api/settings.describe
   # never becomes {url}//api/settings.describe.
-  url="${url%/}"
+  while [[ "$url" == */ ]]; do
+    url="${url%/}"
+  done
 
+  if ! command -v curl >/dev/null 2>&1; then
+    echo "ERROR: runtime probe failed: curl is not available in PATH (required for --runtime)." >&2
+    exit 1
+  fi
+
+  # `--noproxy '*'`: never route the probe through a proxy (localhost dsh web).
   # `|| curl_status=$?` (not `if ! ...; then $?`) — inside an `if !` branch $?
   # is the NEGATED status (0), which would mask curl failures.
-  body="$(curl --silent --show-error --max-time 10 \
+  body="$(curl --noproxy '*' --silent --show-error --max-time 10 \
       --request POST \
       --header 'Content-Type: application/json' \
       --data '{"type":"client-request","rpcId":"verify","method":"settings.describe","payload":{}}' \
@@ -103,7 +111,15 @@ runtime_probe() {
     exit 1
   fi
 
-  if grep -qF '"ns":"advisor"' <<< "$body"; then
+  # Envelope guard (space-tolerant markers): only trust the body when it is a
+  # settings.describe SUCCESS envelope — "ok":true with a namespaces result.
+  # An HTTP error page, an error envelope (ok:false), or garbage must FAIL
+  # instead of being read as "no advisor" / "advisor present".
+  if grep -qE '"ok"[[:space:]]*:[[:space:]]*true' <<< "$body" && grep -qF '"namespaces"' <<< "$body"; then
+    envelope_ok=1
+  fi
+
+  if grep -qE '"ns"[[:space:]]*:[[:space:]]*"advisor"' <<< "$body"; then
     exposed=1
   fi
 
@@ -113,12 +129,7 @@ runtime_probe() {
       echo "ERROR: runtime probe failed: ${url} exposes the advisor namespace (expected absent)." >&2
       exit 1
     fi
-    # Absent-guard: only declare "advisor absent" when the body is a
-    # settings.describe SUCCESS envelope ("ok":true with a namespaces result).
-    # An HTTP error page, an error envelope (ok:false), or garbage must FAIL
-    # instead of passing as "absent". The present direction needs no guard: a
-    # non-envelope response simply lacks "ns":"advisor" and already fails.
-    if ! grep -qF '"ok":true' <<< "$body" || ! grep -qF '"namespaces"' <<< "$body"; then
+    if [[ "$envelope_ok" -eq 0 ]]; then
       [[ "$QUIET" -eq 0 ]] && printf '  [FAIL] runtime probe %-36s unexpected response\n' "(${url})" >&2
       echo "ERROR: runtime probe failed: unexpected response from ${url} (not a settings.describe success envelope) — cannot assert namespace absence." >&2
       exit 1
@@ -128,12 +139,18 @@ runtime_probe() {
     exit 0
   fi
 
+  # present mode: require a success envelope before interpreting exposure —
+  # a non-settings.describe response gets its own distinct failure message.
+  if [[ "$envelope_ok" -eq 0 ]]; then
+    [[ "$QUIET" -eq 0 ]] && printf '  [FAIL] runtime probe %-36s unexpected response\n' "(${url})" >&2
+    echo "ERROR: runtime probe failed: ${url} returned an unexpected response (not a settings.describe success response) — cannot assert namespace exposure." >&2
+    exit 1
+  fi
   if [[ "$exposed" -eq 0 ]]; then
     [[ "$QUIET" -eq 0 ]] && printf '  [FAIL] runtime probe %-36s namespace not exposed\n' "(${url})" >&2
     echo "ERROR: runtime probe failed: ${url} does not expose the advisor namespace (settings.describe response lacks \"ns\":\"advisor\") — the patch is not effective at runtime (server not restarted, or not a dsh web endpoint)." >&2
     exit 1
   fi
-
   [[ "$QUIET" -eq 0 ]] && printf '  [PASS] runtime probe %-36s advisor namespace exposed\n' "(${url})"
   echo "== verify passed: runtime namespace 'advisor' exposed at ${url}"
   exit 0
@@ -153,15 +170,17 @@ if [[ ! -d "$TARGET" ]]; then
   exit 1
 fi
 
-# Probes: (relative path|fixed string|label)
-# NOTE: the tsdown bundle (lib/index.js) is emitted with double-quoted string
-# literals (rolldown/esbuild quote normalization), so its probe marker is the
-# bundle form `"ui-onboarding", "advisor"` rather than the single-quoted source
-# form that appears in src/ and the tsc emit (lib/types/api-proxy.js).
+# Probes: (relative path|match string|label) with an optional match-mode field:
+#   F = fixed string (grep -F, default); E = extended regex (grep -E).
+# The src / tsc-emit probes keep the literal single-quoted source marker. The
+# tsdown bundle (lib/index.js) probe is quote- and order-agnostic: it greps the
+# PRODUCT_SETTINGS_NAMESPACES assignment context (up to the statement's `;`)
+# for `advisor`, so it matches both the single-quoted source form and the
+# double-quoted bundle form (`new Set(["ui-onboarding", "advisor"])`).
 PROBES=(
   "packages/host/apiproxy/src/api-proxy.ts|'ui-onboarding', 'advisor'|host-apiproxy source (src/api-proxy.ts)"
   "packages/host/apiproxy/lib/types/api-proxy.js|'ui-onboarding', 'advisor'|host-apiproxy build (lib/types/api-proxy.js)"
-  "packages/host/apiproxy/lib/index.js|\"ui-onboarding\", \"advisor\"|host-apiproxy bundle (lib/index.js)"
+  "packages/host/apiproxy/lib/index.js|PRODUCT_SETTINGS_NAMESPACES[^;]*advisor|host-apiproxy bundle (lib/index.js)|E"
 )
 
 EXPECT_LABEL="present"
@@ -171,17 +190,26 @@ FAIL=0
 CHECKED=0
 
 for probe in "${PROBES[@]}"; do
-  IFS='|' read -r rel marker label <<< "$probe"
+  IFS='|' read -r rel marker label mode <<< "$probe"
+  mode="${mode:-F}"
   file="${TARGET}/${rel}"
   if [[ ! -f "$file" ]]; then
     [[ "$QUIET" -eq 0 ]] && printf '  [SKIP] %-52s file missing\n' "$label"
     continue
   fi
   CHECKED=1
-  if grep -qF -- "$marker" "$file"; then
-    present=1
+  if [[ "$mode" == "E" ]]; then
+    if grep -qE -- "$marker" "$file"; then
+      present=1
+    else
+      present=0
+    fi
   else
-    present=0
+    if grep -qF -- "$marker" "$file"; then
+      present=1
+    else
+      present=0
+    fi
   fi
   if [[ "$ABSENT" -eq 1 ]]; then
     # marker must be absent: presence is a failure

--- a/src/client/locales.ts
+++ b/src/client/locales.ts
@@ -31,7 +31,7 @@ export const en = {
   saved: 'Advisor settings saved. New sessions pick them up immediately.',
   conflict: 'The settings changed elsewhere. Review the values and apply again.',
   readOnly: 'Settings are read-only in this environment.',
-  namespaceUnavailable: 'The advisor settings namespace is unavailable in this dsh build (not exposed by the host). Configure the advisor via the plugin config row or the /advisor command instead.',
+  namespaceUnavailable: 'The advisor settings namespace is not exposed by this dsh build. Configure the advisor via the plugin config row (`id: advisor` with `enabled`/`provider`/`model` in `$DSH_HOME/profiles/<name>/cordis.patch.yml`), or apply the host exposure patch under `patches/` (scripts/apply-dsh-patch.sh) and restart dsh web. Note: `/advisor` only toggles the advisor per session; it cannot supply provider/model.',
 }
 
 /** The settings.advisor namespace key union. */
@@ -64,5 +64,5 @@ export const zh: typeof en = {
   saved: '顾问设置已保存。新会话立即生效。',
   conflict: '设置已在别处变更。请核对当前值后重新保存。',
   readOnly: '当前环境中的设置为只读。',
-  namespaceUnavailable: '当前 dsh 构建未暴露 advisor 设置命名空间。请改用插件配置行或 /advisor 指令配置顾问。',
+  namespaceUnavailable: '当前 dsh 构建未暴露 advisor 设置命名空间。请通过插件配置行配置顾问（在 `$DSH_HOME/profiles/<name>/cordis.patch.yml` 中写 `id: advisor` 并设置 `enabled`/`provider`/`model`），或应用 `patches/` 下的宿主暴露补丁（scripts/apply-dsh-patch.sh）并重启 dsh web。注意：`/advisor` 仅切换当前会话的顾问开关，无法提供 provider/model。',
 }

--- a/src/client/locales.ts
+++ b/src/client/locales.ts
@@ -31,7 +31,7 @@ export const en = {
   saved: 'Advisor settings saved. New sessions pick them up immediately.',
   conflict: 'The settings changed elsewhere. Review the values and apply again.',
   readOnly: 'Settings are read-only in this environment.',
-  namespaceUnavailable: 'The advisor settings namespace is not exposed by this dsh build. Configure the advisor via the plugin config row (`id: advisor` with `enabled`/`provider`/`model` in `$DSH_HOME/profiles/<name>/cordis.patch.yml`), or apply the host exposure patch under `patches/` (scripts/apply-dsh-patch.sh) and restart dsh web. Note: `/advisor` only toggles the advisor per session; it cannot supply provider/model.',
+  namespaceUnavailable: 'The advisor settings namespace is not exposed by this dsh build. Configure the advisor via the plugin config row — `- id: advisor` whose `config:` map sets `enabled`/`provider`/`model` (e.g. `config: { enabled: true, provider: …, model: … }`) in `$DSH_HOME/profiles/<name>/cordis.patch.yml` — or apply the host exposure patch under `patches/` (scripts/apply-dsh-patch.sh) and restart dsh web. Note: `/advisor` only toggles the advisor per session; it cannot supply provider/model.',
 }
 
 /** The settings.advisor namespace key union. */
@@ -64,5 +64,5 @@ export const zh: typeof en = {
   saved: '顾问设置已保存。新会话立即生效。',
   conflict: '设置已在别处变更。请核对当前值后重新保存。',
   readOnly: '当前环境中的设置为只读。',
-  namespaceUnavailable: '当前 dsh 构建未暴露 advisor 设置命名空间。请通过插件配置行配置顾问（在 `$DSH_HOME/profiles/<name>/cordis.patch.yml` 中写 `id: advisor` 并设置 `enabled`/`provider`/`model`），或应用 `patches/` 下的宿主暴露补丁（scripts/apply-dsh-patch.sh）并重启 dsh web。注意：`/advisor` 仅切换当前会话的顾问开关，无法提供 provider/model。',
+  namespaceUnavailable: '当前 dsh 构建未暴露 advisor 设置命名空间。请通过插件配置行配置顾问——在 `$DSH_HOME/profiles/<name>/cordis.patch.yml` 中写 `- id: advisor`，其 `config:` 映射中设置 `enabled`/`provider`/`model`（例如 `config: { enabled: true, provider: …, model: … }`）；或应用 `patches/` 下的宿主暴露补丁（scripts/apply-dsh-patch.sh）并重启 dsh web。注意：`/advisor` 仅切换当前会话的顾问开关，无法提供 provider/model。',
 }

--- a/tests/advisor-section.spec.tsx
+++ b/tests/advisor-section.spec.tsx
@@ -20,7 +20,7 @@ import { bindSnapshotSelector } from '@deepseek-ai/dsh-client-web-react'
 import { AdvisorSection } from '../src/client/advisor-section'
 import type { AdvisorSectionInjected, AdvisorSectionProps } from '../src/client/advisor-section'
 import { AdvisorSettingsStore } from '../src/client/advisor-store'
-import { en } from '../src/client/locales'
+import { en, zh } from '../src/client/locales'
 
 afterEach(cleanup)
 
@@ -367,11 +367,30 @@ describe('AdvisorSection', () => {
     // exposure boundary): the form must not present defaults + a writable
     // Apply that the host would refuse — the notice replaces it.
     await mountSection({ advisor: null })
-    expect(screen.getByText(en.namespaceUnavailable)).toBeTruthy()
+    const notice = screen.getByText(en.namespaceUnavailable)
+    expect(notice).toBeTruthy()
+    // Host-exposure-fix task 2: the notice must point at the working config
+    // path (the plugin config row in the profile's cordis.patch.yml) and must
+    // not suggest /advisor as a configuration channel — it is a per-session
+    // toggle only and cannot supply provider/model.
+    expect(notice.textContent).toContain('cordis.patch.yml')
+    expect(notice.textContent).toContain('/advisor')
+    expect(notice.textContent).toMatch(/only toggles the advisor per session/i)
+    expect(notice.textContent).toMatch(/cannot supply provider\/model/i)
     expect(screen.queryByRole('button', { name: en.apply })).toBeNull()
     expect(screen.queryByRole('button', { name: en.cancel })).toBeNull()
     expect(screen.queryByLabelText(en.enabled)).toBeNull()
     expect(screen.queryByLabelText(en.provider)).toBeNull()
+  })
+
+  it('mirrors the unexposed-namespace guidance in zh (plugin config row + toggle-only /advisor)', () => {
+    // The zh dictionary mirrors en; the guidance must carry the same key
+    // content: the cordis.patch.yml config row and the /advisor toggle-only
+    // clarification (it cannot supply provider/model).
+    expect(zh.namespaceUnavailable).toContain('cordis.patch.yml')
+    expect(zh.namespaceUnavailable).toContain('/advisor')
+    expect(zh.namespaceUnavailable).toMatch(/开关/)
+    expect(zh.namespaceUnavailable).toMatch(/无法提供|不能提供/)
   })
 
   it('renders the load failure with a working retry', async () => {

--- a/tests/advisor-section.spec.tsx
+++ b/tests/advisor-section.spec.tsx
@@ -374,6 +374,8 @@ describe('AdvisorSection', () => {
     // not suggest /advisor as a configuration channel — it is a per-session
     // toggle only and cannot supply provider/model.
     expect(notice.textContent).toContain('cordis.patch.yml')
+    // qc2 W-1: the guidance must name the `config:` map nesting explicitly.
+    expect(notice.textContent).toContain('config:')
     expect(notice.textContent).toContain('/advisor')
     expect(notice.textContent).toMatch(/only toggles the advisor per session/i)
     expect(notice.textContent).toMatch(/cannot supply provider\/model/i)
@@ -388,6 +390,8 @@ describe('AdvisorSection', () => {
     // content: the cordis.patch.yml config row and the /advisor toggle-only
     // clarification (it cannot supply provider/model).
     expect(zh.namespaceUnavailable).toContain('cordis.patch.yml')
+    // qc2 W-1: the zh mirror must name the `config:` map nesting like en.
+    expect(zh.namespaceUnavailable).toContain('config:')
     expect(zh.namespaceUnavailable).toContain('/advisor')
     expect(zh.namespaceUnavailable).toMatch(/开关/)
     expect(zh.namespaceUnavailable).toMatch(/无法提供|不能提供/)

--- a/tests/host-patch.test.ts
+++ b/tests/host-patch.test.ts
@@ -19,7 +19,8 @@
 
 import { describe, expect, it } from 'vitest'
 import { existsSync, readFileSync } from 'node:fs'
-import { spawnSync } from 'node:child_process'
+import { spawn, spawnSync } from 'node:child_process'
+import { createServer } from 'node:http'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -122,6 +123,109 @@ describe('host exposure patch artifact (C-1)', () => {
     // The distinct "server unreachable" message must name the probed URL —
     // proving the --runtime mode ran (as opposed to an option-parse error).
     expect(out.stderr, 'unreachable failure names the probed URL').toContain(url)
+  })
+
+  // One-shot localhost HTTP server answering ONLY the canonical
+  // settings.describe path (anything else → 404). This lets the tests exercise
+  // the runtime probe deterministically without touching any dsh tree.
+  //
+  // NOTE: the server must run ASYNC (and the verify script must be spawned
+  // asynchronously): spawnSync blocks the event loop, so a same-thread server
+  // can never answer the probe's curl request (it times out with 0 bytes).
+  function startDescribeServer(responseBody: string): Promise<{ url: string; close: () => void }> {
+    return new Promise((resolvePromise, reject) => {
+      const server = createServer((req, res) => {
+        if (req.url !== '/api/settings.describe') {
+          res.writeHead(404, { 'Content-Type': 'text/plain' })
+          res.end('not found')
+          return
+        }
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(responseBody)
+      })
+      server.on('error', reject)
+      server.listen(0, '127.0.0.1', () => {
+        const addr = server.address()
+        if (!addr || typeof addr === 'string') {
+          server.close()
+          reject(new Error('server did not bind a TCP port'))
+          return
+        }
+        resolvePromise({ url: `http://127.0.0.1:${addr.port}`, close: () => server.close() })
+      })
+    })
+  }
+
+  function runAsync(args: string[]): Promise<{ status: number | null; stdout: string; stderr: string }> {
+    return new Promise((resolvePromise, reject) => {
+      const child = spawn(args[0], args.slice(1), { cwd: repo, env: process.env })
+      let stdout = ''
+      let stderr = ''
+      child.stdout.setEncoding('utf8')
+      child.stderr.setEncoding('utf8')
+      child.stdout.on('data', (d: string) => (stdout += d))
+      child.stderr.on('data', (d: string) => (stderr += d))
+      child.on('error', reject)
+      child.on('close', (code: number | null) => resolvePromise({ status: code, stdout, stderr }))
+    })
+  }
+
+  // Realistic settings.describe response bodies (mirroring the live dsh web
+  // envelope {"type":"server-response","rpcId":...,"result":{"ok":...,"value":
+  // {"writable":...,"hasDocument":...,"namespaces":[...]}}}).
+  const SUCCESS_NO_ADVISOR = JSON.stringify({
+    type: 'server-response',
+    rpcId: 'verify',
+    result: { ok: true, value: { writable: true, hasDocument: true, namespaces: [{ ns: 'ui-onboarding' }] } },
+  })
+  const SUCCESS_WITH_ADVISOR = JSON.stringify({
+    type: 'server-response',
+    rpcId: 'verify',
+    result: {
+      ok: true,
+      value: { writable: true, hasDocument: true, namespaces: [{ ns: 'ui-onboarding' }, { ns: 'advisor' }] },
+    },
+  })
+  const ERROR_ENVELOPE = JSON.stringify({
+    type: 'server-response',
+    rpcId: 'verify',
+    result: { ok: false, error: 'settings-not-exposed' },
+  })
+
+  it('verify-dsh-patch.sh --runtime --absent fails on a non-success response (envelope guard)', async () => {
+    // An error envelope lacks the success markers — it must FAIL as
+    // "unexpected response" instead of passing as "advisor absent".
+    const server = await startDescribeServer(ERROR_ENVELOPE)
+    try {
+      const out = await runAsync(['bash', 'scripts/verify-dsh-patch.sh', '--runtime', server.url, '--absent'])
+      expect(out.status, `envelope guard exits non-zero — stderr:\n${out.stderr}`).not.toBe(0)
+      expect(out.stderr, 'guard message names the success envelope').toContain('success envelope')
+    } finally {
+      server.close()
+    }
+  })
+
+  it('verify-dsh-patch.sh --runtime --absent passes on a success envelope without advisor (trailing slash tolerated)', async () => {
+    // Trailing slash: the script must normalize {url}/ before appending
+    // /api/settings.describe — the helper only answers the canonical path, so
+    // a double-slash URL would 404 and trip the envelope guard.
+    const server = await startDescribeServer(SUCCESS_NO_ADVISOR)
+    try {
+      const out = await runAsync(['bash', 'scripts/verify-dsh-patch.sh', '--runtime', `${server.url}/`, '--absent'])
+      expect(out.status, `absent-on-success exit 0 — stderr:\n${out.stderr}`).toBe(0)
+    } finally {
+      server.close()
+    }
+  })
+
+  it('verify-dsh-patch.sh --runtime present direction still passes on a success envelope with advisor', async () => {
+    const server = await startDescribeServer(SUCCESS_WITH_ADVISOR)
+    try {
+      const out = await runAsync(['bash', 'scripts/verify-dsh-patch.sh', '--runtime', server.url])
+      expect(out.status, `present-on-success exit 0 — stderr:\n${out.stderr}`).toBe(0)
+    } finally {
+      server.close()
+    }
   })
 
   const target = resolveTarget()

--- a/tests/host-patch.test.ts
+++ b/tests/host-patch.test.ts
@@ -62,6 +62,9 @@ function sourceIsPatched(tree: string): boolean {
   return readFileSync(source, 'utf8').includes(MARKER)
 }
 
+/** --runtime needs curl in PATH; skip the live-probe tests where it is missing. */
+const curlAvailable = spawnSync('bash', ['-c', 'command -v curl'], { encoding: 'utf8' }).status === 0
+
 describe('host exposure patch artifact (C-1)', () => {
   it('ships the patch as a git diff with the expected allowlist change', () => {
     expect(existsSync(PATCH_FILE), `${PATCH} exists under patches/`).toBe(true)
@@ -105,16 +108,17 @@ describe('host exposure patch artifact (C-1)', () => {
     expect(probes, 'bundle probe entry for the tsdown bundle (package main)').toContain(
       'packages/host/apiproxy/lib/index.js',
     )
-    // tsdown emits double-quoted string literals, so the bundle probe marker
-    // is the bundle form — the single-quoted source form never appears there.
-    // (In the bash source the marker is written with escaped quotes because
-    // the probe entry is itself a double-quoted string.)
-    expect(probes, 'bundle probe uses the double-quoted bundle marker').toContain('\\"ui-onboarding\\", \\"advisor\\"')
+    // The bundle probe is quote-agnostic: it greps the PRODUCT_SETTINGS_NAMESPACES
+    // assignment context for `advisor` (tsdown emits double-quoted literals, so
+    // the single-quoted source marker never appears there).
+    expect(probes, 'bundle probe greps the assignment context, quote-agnostic').toContain(
+      'PRODUCT_SETTINGS_NAMESPACES[^;]*advisor',
+    )
     // The source / tsc-emit probes keep the single-quoted source form.
     expect(probes, 'source/build probes keep the single-quoted marker').toContain(MARKER)
   })
 
-  it('verify-dsh-patch.sh --runtime exits non-zero against an unreachable server', () => {
+  it.skipIf(!curlAvailable)('verify-dsh-patch.sh --runtime exits non-zero against an unreachable server', () => {
     // Deterministic and sandbox-safe: nothing listens on port 1, so curl fails
     // with connection refused regardless of the local dsh tree / server state.
     const url = 'http://127.0.0.1:1'
@@ -126,22 +130,42 @@ describe('host exposure patch artifact (C-1)', () => {
   })
 
   // One-shot localhost HTTP server answering ONLY the canonical
-  // settings.describe path (anything else → 404). This lets the tests exercise
-  // the runtime probe deterministically without touching any dsh tree.
+  // settings.describe path via a POST carrying the client-request envelope
+  // (anything else → 404/400). This lets the tests exercise the runtime probe
+  // deterministically without touching any dsh tree.
   //
   // NOTE: the server must run ASYNC (and the verify script must be spawned
   // asynchronously): spawnSync blocks the event loop, so a same-thread server
   // can never answer the probe's curl request (it times out with 0 bytes).
-  function startDescribeServer(responseBody: string): Promise<{ url: string; close: () => void }> {
+  function startDescribeServer(
+    responseBody: string,
+    status = 200,
+  ): Promise<{ url: string; close: () => Promise<void> }> {
     return new Promise((resolvePromise, reject) => {
       const server = createServer((req, res) => {
-        if (req.url !== '/api/settings.describe') {
+        if (req.method !== 'POST' || req.url !== '/api/settings.describe') {
           res.writeHead(404, { 'Content-Type': 'text/plain' })
           res.end('not found')
           return
         }
-        res.writeHead(200, { 'Content-Type': 'application/json' })
-        res.end(responseBody)
+        let body = ''
+        req.on('data', (chunk: Buffer) => (body += chunk.toString('utf8')))
+        req.on('end', () => {
+          // The probe must send the settings.describe client-request envelope.
+          let envelopeOk = false
+          try {
+            envelopeOk = JSON.parse(body).method === 'settings.describe'
+          } catch {
+            envelopeOk = false
+          }
+          if (!envelopeOk) {
+            res.writeHead(400, { 'Content-Type': 'text/plain' })
+            res.end('unexpected envelope')
+            return
+          }
+          res.writeHead(status, { 'Content-Type': 'application/json' })
+          res.end(responseBody)
+        })
       })
       server.on('error', reject)
       server.listen(0, '127.0.0.1', () => {
@@ -151,7 +175,14 @@ describe('host exposure patch artifact (C-1)', () => {
           reject(new Error('server did not bind a TCP port'))
           return
         }
-        resolvePromise({ url: `http://127.0.0.1:${addr.port}`, close: () => server.close() })
+        resolvePromise({
+          url: `http://127.0.0.1:${addr.port}`,
+          close: () =>
+            new Promise<void>((done) => {
+              server.closeAllConnections()
+              server.close(() => done())
+            }),
+        })
       })
     })
   }
@@ -192,40 +223,80 @@ describe('host exposure patch artifact (C-1)', () => {
     result: { ok: false, error: 'settings-not-exposed' },
   })
 
-  it('verify-dsh-patch.sh --runtime --absent fails on a non-success response (envelope guard)', async () => {
-    // An error envelope lacks the success markers — it must FAIL as
-    // "unexpected response" instead of passing as "advisor absent".
-    const server = await startDescribeServer(ERROR_ENVELOPE)
-    try {
-      const out = await runAsync(['bash', 'scripts/verify-dsh-patch.sh', '--runtime', server.url, '--absent'])
-      expect(out.status, `envelope guard exits non-zero — stderr:\n${out.stderr}`).not.toBe(0)
-      expect(out.stderr, 'guard message names the success envelope').toContain('success envelope')
-    } finally {
-      server.close()
-    }
-  })
+  it.skipIf(!curlAvailable)(
+    'verify-dsh-patch.sh --runtime --absent fails on a non-success response (envelope guard)',
+    async () => {
+      // An error envelope lacks the success markers — it must FAIL as
+      // "unexpected response" instead of passing as "advisor absent".
+      const server = await startDescribeServer(ERROR_ENVELOPE)
+      try {
+        const out = await runAsync(['bash', 'scripts/verify-dsh-patch.sh', '--runtime', server.url, '--absent'])
+        expect(out.status, `envelope guard exits non-zero — stderr:\n${out.stderr}`).not.toBe(0)
+        expect(out.stderr, 'guard message names the success envelope').toContain('success envelope')
+      } finally {
+        await server.close()
+      }
+    },
+  )
 
-  it('verify-dsh-patch.sh --runtime --absent passes on a success envelope without advisor (trailing slash tolerated)', async () => {
-    // Trailing slash: the script must normalize {url}/ before appending
-    // /api/settings.describe — the helper only answers the canonical path, so
-    // a double-slash URL would 404 and trip the envelope guard.
-    const server = await startDescribeServer(SUCCESS_NO_ADVISOR)
-    try {
-      const out = await runAsync(['bash', 'scripts/verify-dsh-patch.sh', '--runtime', `${server.url}/`, '--absent'])
-      expect(out.status, `absent-on-success exit 0 — stderr:\n${out.stderr}`).toBe(0)
-    } finally {
-      server.close()
-    }
-  })
+  it.skipIf(!curlAvailable)(
+    'verify-dsh-patch.sh --runtime --absent passes on a success envelope without advisor (trailing slashes tolerated)',
+    async () => {
+      // Trailing slashes: the script must normalize {url}/.../ before appending
+      // /api/settings.describe — the helper only answers the canonical path, so
+      // a double-slash URL would 404 and trip the envelope guard.
+      const server = await startDescribeServer(SUCCESS_NO_ADVISOR)
+      try {
+        const out = await runAsync(['bash', 'scripts/verify-dsh-patch.sh', '--runtime', `${server.url}//`, '--absent'])
+        expect(out.status, `absent-on-success exit 0 — stderr:\n${out.stderr}`).toBe(0)
+      } finally {
+        await server.close()
+      }
+    },
+  )
 
-  it('verify-dsh-patch.sh --runtime present direction still passes on a success envelope with advisor', async () => {
-    const server = await startDescribeServer(SUCCESS_WITH_ADVISOR)
-    try {
-      const out = await runAsync(['bash', 'scripts/verify-dsh-patch.sh', '--runtime', server.url])
-      expect(out.status, `present-on-success exit 0 — stderr:\n${out.stderr}`).toBe(0)
-    } finally {
-      server.close()
-    }
+  it.skipIf(!curlAvailable)(
+    'verify-dsh-patch.sh --runtime present direction still passes on a success envelope with advisor',
+    async () => {
+      const server = await startDescribeServer(SUCCESS_WITH_ADVISOR)
+      try {
+        const out = await runAsync(['bash', 'scripts/verify-dsh-patch.sh', '--runtime', server.url])
+        expect(out.status, `present-on-success exit 0 — stderr:\n${out.stderr}`).toBe(0)
+      } finally {
+        await server.close()
+      }
+    },
+  )
+
+  it.skipIf(!curlAvailable)(
+    'verify-dsh-patch.sh --runtime present direction fails on a non-envelope response with a distinct message',
+    async () => {
+      // A 404 error page is not a settings.describe success response: present
+      // mode must FAIL with the envelope message, not the "advisor not exposed"
+      // message (which would imply a reachable, unpatched server).
+      const server = await startDescribeServer('Internal Server Error', 404)
+      try {
+        const out = await runAsync(['bash', 'scripts/verify-dsh-patch.sh', '--runtime', server.url])
+        expect(out.status, `present-on-404 exits non-zero — stderr:\n${out.stderr}`).not.toBe(0)
+        expect(out.stderr, 'distinct non-success-response message').toContain('success response')
+        expect(out.stderr, 'must not be the plain not-exposed message').not.toContain(
+          'does not expose the advisor namespace',
+        )
+      } finally {
+        await server.close()
+      }
+    },
+  )
+
+  it.skipIf(!curlAvailable)('verify-dsh-patch.sh --runtime reports a distinct error when curl is missing', () => {
+    // Strip curl from PATH (bash is invoked by absolute path so it still runs);
+    // the script must fail with the curl-missing message instead of a
+    // connection error.
+    const out = run(['/bin/bash', 'scripts/verify-dsh-patch.sh', '--runtime', 'http://127.0.0.1:1'], {
+      env: { ...process.env, PATH: '/nonexistent' },
+    })
+    expect(out.status, `exit non-zero — stderr:\n${out.stderr}`).not.toBe(0)
+    expect(out.stderr, 'distinct curl-missing message').toContain('curl is not available')
   })
 
   const target = resolveTarget()

--- a/tests/host-patch.test.ts
+++ b/tests/host-patch.test.ts
@@ -92,6 +92,38 @@ describe('host exposure patch artifact (C-1)', () => {
     expect(out.status, `autopatch opt-out exit 0 — stderr:\n${out.stderr}`).toBe(0)
   })
 
+  it('verify-dsh-patch.sh probes the tsdown bundle (lib/index.js) as a third file probe', () => {
+    const script = readFileSync(resolve(scriptsDir, 'verify-dsh-patch.sh'), 'utf8')
+    // Extract the PROBES=(...) array block line-wise (labels contain ")" so a
+    // regex like /PROBES=\((.*?)\)/s would truncate at the first label).
+    const lines = script.split('\n')
+    const start = lines.findIndex((l) => l.startsWith('PROBES=('))
+    const end = lines.indexOf(')', start)
+    const probes = start >= 0 && end > start ? lines.slice(start + 1, end).join('\n') : ''
+    expect(probes, 'PROBES array block present in verify-dsh-patch.sh').not.toBe('')
+    expect(probes, 'bundle probe entry for the tsdown bundle (package main)').toContain(
+      'packages/host/apiproxy/lib/index.js',
+    )
+    // tsdown emits double-quoted string literals, so the bundle probe marker
+    // is the bundle form — the single-quoted source form never appears there.
+    // (In the bash source the marker is written with escaped quotes because
+    // the probe entry is itself a double-quoted string.)
+    expect(probes, 'bundle probe uses the double-quoted bundle marker').toContain('\\"ui-onboarding\\", \\"advisor\\"')
+    // The source / tsc-emit probes keep the single-quoted source form.
+    expect(probes, 'source/build probes keep the single-quoted marker').toContain(MARKER)
+  })
+
+  it('verify-dsh-patch.sh --runtime exits non-zero against an unreachable server', () => {
+    // Deterministic and sandbox-safe: nothing listens on port 1, so curl fails
+    // with connection refused regardless of the local dsh tree / server state.
+    const url = 'http://127.0.0.1:1'
+    const out = run(['bash', 'scripts/verify-dsh-patch.sh', '--runtime', url])
+    expect(out.status, `runtime probe exits non-zero — stderr:\n${out.stderr}`).not.toBe(0)
+    // The distinct "server unreachable" message must name the probed URL —
+    // proving the --runtime mode ran (as opposed to an option-parse error).
+    expect(out.stderr, 'unreachable failure names the probed URL').toContain(url)
+  })
+
   const target = resolveTarget()
 
   describe.skipIf(!target)('against the reachable dsh source tree', () => {


### PR DESCRIPTION
## Summary

修复 dsh-advisor 在 `dsh web --profile web` 环境中的失效问题（Settings 页「未暴露 advisor 命名空间」+ `/advisor` 指令看似无效果），并关闭 residual R1（宿主 settings 暴露白名单缺 `advisor`）。

**RCA（含运行时证据）**
- 运行中的宿主 = `$DSH_HOME/source/current` staging 快照，launcher 经 **tsx 直接执行 TypeScript 源码**（tsconfig paths 把 `@deepseek-ai/dsh-host-apiproxy` 映射到 `packages/host/apiproxy/src`）；之前补丁未打到该运行时树 → `settings.describe` 无 `advisor`。
- `/advisor` 指令本身是活的（command.list / command.execute 均匹配），但 S4 硬门拦截：`provider`/`model` 从未配置 → advisor 无法发起模型调用 → 无评审注入，表现为「没效果」。

## Changes

**Tooling（`scripts/` + `patches/`）**
- `verify-dsh-patch.sh`：
  - 新增第三个文件探针 `packages/host/apiproxy/lib/index.js`（tsdown bundle，package `main`；双引号 marker，空格容错）。
  - 新增 `--runtime [URL]` 实时探针：POST `{url}/api/settings.describe`（envelope `client-request` / `settings.describe`，10s 超时，`--noproxy '*'`），断言 `advisor` 命名空间暴露/未暴露；区分「服务器不可达（未运行/未重启）」与「未暴露」；双方向 success-envelope 守卫；URL 尾部斜杠归一化。
- `apply-dsh-patch.sh`：usage 覆盖完整头部；文档注明 tsx 源码运行时 → 重启才生效、lib 仅一致性。
- `patches/README.md`：新增「Runtime shape」章节（tsx-from-source 安装、重启语义、upgrade 后重打、dsh-private 快照继承、`--runtime` 用法与只读无凭据说明）。

**Client guidance（`src/client/`）**
- `namespaceUnavailable`（en/zh）：修正误导性文案（原「或 /advisor 指令配置顾问」——`/advisor` 仅会话级开关，无法提供 provider/model）；改为正确指引：插件配置行（`- id: advisor` 的 `config:` 映射设置 `enabled`/`provider`/`model`）+ 宿主补丁 + 重启路径。

**Tests**
- `tests/host-patch.test.ts`：本地 loopback HTTP server 确定性测试 runtime 探针（present/absent/envelope-guard/trailing-slash/POST 契约）、端口 1 不可达测试、curl 缺失守卫。
- `tests/advisor-section.spec.tsx`：未暴露提示文案断言（`config:` 映射 + `/advisor` 仅开关说明）+ zh 镜像。

## Verification

- `pnpm test`：223 passed | 2 skipped（15 files）· `pnpm typecheck` 0 · `pnpm build` 0
- 仓库内 plan 门禁：L2 task review ×2 Approve；plan QC tri（qc1/qc2/qc3）→ 修复波次后全 Approve；QA gate mandatory **PASS**（repo-side + live round-trip）
- 运行环境（本机，operator 步骤）：补丁应用至 `$DSH_HOME/source/current`（运行时树）与 `dsh-private`（未来快照继承），lib 重建；profile `cordis.patch.yml` 写入 advisor 配置行（HMR 生效）；重启后实测 `settings.describe` 含 `advisor`、`verify-dsh-patch.sh --runtime` exit 0、`/advisor status` → enabled + deepseek-official/deepseek-v4-flash + runtime running、`settings.update` 写入往返成功。
- R1 已关闭归档（`.mstar/archived/residuals/dsh-advisor-settings-n2.json`）。

## Notes

- 本 PR 只含仓库侧改动（5 commits）；运行环境修复为 operator 步骤，不在 diff 内。
- 未来 dsh 升级（换 staging）会重置补丁：升级后重跑 `scripts/apply-dsh-patch.sh` 并用 `scripts/verify-dsh-patch.sh --runtime` 验证。
