### PR TITLE
chore(release): bump dsh-advisor to 0.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-advisor",
-  "version": "0.0.1-rc.5",
+  "version": "0.1.0",
   "type": "module",
   "description": "dsh plugin bundle porting the omp advisor subsystem: a per-session reviewer model that observes the primary transcript and injects severity-ranked advice (nit/concern/blocker).",
   "keywords": [


### PR DESCRIPTION
Version bump only: `0.0.1-rc.5` → `0.1.0`, aligning with the dsh 0.1.0 dependency line (all `@deepseek-ai/dsh-*` peers now resolve at `^0.1.0-rc.3`).

Single-file change (package.json). No source edits; lockfile unaffected.