### PR TITLE
fix: use DSH scoped schemastery peer

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ dsh plugin --profile web add dsh-advisor   # <name> = your profile name
 
 A registry install fetches the published tarball, which ships the built
 artifacts (`lib/` + `cordis.patch.yml`), so no `prepare` build or build
-permission is needed. Runtime dependencies (`@deepseek-ai/cordis`, `schemastery`,
+permission is needed. Runtime dependencies (`@deepseek-ai/cordis`, `@deepseek-ai/schemastery`,
 and the `@deepseek-ai/dsh-*` peers) are declared as peerDependencies and resolve
 through the dsh installation's flat profile module fallback — no extra install
 step. Pin an exact version (`dsh-advisor@0.1.0`) for reproducible installs.
@@ -277,7 +277,7 @@ bin-less cordis shim at `node_modules/@deepseek-ai/cordis` answers the scoped
 name and resolves to the vendored files, because the real packages type and
 run against the vendored build and module identity requires dev-time
 `import '@deepseek-ai/cordis'` to resolve to the same files. The public
-devDependencies (`schemastery`, `react`, …) resolve from the npm registry as
+devDependencies (`@deepseek-ai/schemastery`, `react`, …) resolve from the npm registry as
 usual.
 
 `prepack` runs `pnpm build`; `prepare` runs the link farm and the build, so

--- a/README.zh.md
+++ b/README.zh.md
@@ -24,7 +24,7 @@ dsh plugin --profile web add dsh-advisor   # <name> = 你的 profile 名
 dsh plugin --profile web add dsh-advisor   # <name> = 你的 profile 名
 ```
 
-registry 安装拉取的是已发布的 tarball，其中自带构建产物（`lib/` + `cordis.patch.yml`），因此不会运行 `prepare` 构建，也无需构建放行。运行时依赖（`@deepseek-ai/cordis`、`schemastery` 与 `@deepseek-ai/dsh-*` peers）声明为 peerDependencies，由 dsh 安装的扁平 profile module fallback 解析——无需额外安装步骤。需要可复现安装时用 `dsh-advisor@0.1.0` 钉住精确版本。
+registry 安装拉取的是已发布的 tarball，其中自带构建产物（`lib/` + `cordis.patch.yml`），因此不会运行 `prepare` 构建，也无需构建放行。运行时依赖（`@deepseek-ai/cordis`、`@deepseek-ai/schemastery` 与 `@deepseek-ai/dsh-*` peers）声明为 peerDependencies，由 dsh 安装的扁平 profile module fallback 解析——无需额外安装步骤。需要可复现安装时用 `dsh-advisor@0.1.0` 钉住精确版本。
 
 ### 本地目录安装（推荐用于开发 / 验证）
 
@@ -149,7 +149,7 @@ pnpm pack                 # build + produce dsh-advisor-0.0.1.tgz
 
 Windows 上链接农场的目录条目以 junction 创建（无需特权），但 cordis shim 的文件条目使用文件符号链接，需要开启[开发者模式](https://learn.microsoft.com/windows/apps/get-started/enable-your-device-for-development)（或以管理员 shell 运行）——请先开启再执行 `pnpm install`。Windows 没有 `HOME`，脚本回退到 `USERPROFILE` 解析 dsh 源码树。
 
-内置 `cordis` 框架声明为 scoped peer `@deepseek-ai/cordis: ^4.0.1-rc.1`（范围必须带精确的发布 tag —— 带 prerelease 的 comparator 只匹配同 `[major, minor, patch]` tuple，`^4.0.0-rc.7` 永远不匹配 vendored 的 `4.0.1-rc.1`）；安装后链接农场的无 bin cordis shim 位于 `node_modules/@deepseek-ai/cordis`，以 scoped 名应答并解析到 vendored 文件，因为真实包是对着 vendored 构建类型化/运行的，模块身份要求开发期的 `import '@deepseek-ai/cordis'` 解析到同一份文件。其余公开 devDependencies（`schemastery`、`react` 等）照常从 npm registry 解析。
+内置 `cordis` 框架声明为 scoped peer `@deepseek-ai/cordis: ^4.0.1-rc.1`（范围必须带精确的发布 tag —— 带 prerelease 的 comparator 只匹配同 `[major, minor, patch]` tuple，`^4.0.0-rc.7` 永远不匹配 vendored 的 `4.0.1-rc.1`）；安装后链接农场的无 bin cordis shim 位于 `node_modules/@deepseek-ai/cordis`，以 scoped 名应答并解析到 vendored 文件，因为真实包是对着 vendored 构建类型化/运行的，模块身份要求开发期的 `import '@deepseek-ai/cordis'` 解析到同一份文件。其余公开 devDependencies（`@deepseek-ai/schemastery`、`react` 等）照常从 npm registry 解析。
 
 `prepack` 运行 `pnpm build`；`prepare` 运行链接农场与构建，因此 `pnpm pack` 会构建两次（每个生命周期一次）——这是为保持 git 安装可构建而接受的取舍。没有 `postinstall` 步骤：tarball 安装已带构建产物，完全跳过构建。
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -24,7 +24,7 @@ dsh plugin --profile web add dsh-advisor   # <name> = your profile name
 A registry install fetches the published tarball, which ships the built
 artifacts (`lib/` + `cordis.patch.yml`) and has no `install` / `postinstall`
 scripts — no `prepare` build runs and no build permission is needed. Runtime
-dependencies (`@deepseek-ai/cordis`, `schemastery`, and the `@deepseek-ai/dsh-*`
+dependencies (`@deepseek-ai/cordis`, `@deepseek-ai/schemastery`, and the `@deepseek-ai/dsh-*`
 peers) are declared as peerDependencies and resolved by the dsh installation's
 flat profile module fallback — no extra install step.
 
@@ -57,7 +57,7 @@ dsh plugin --profile web add dsh-advisor-0.1.0.tgz
 
 A tarball ships the built artifacts (`lib/` + `cordis.patch.yml`), so no
 `prepare` script runs and no build permission is needed. Runtime dependencies
-(`cordis`, `schemastery`, and `@deepseek-ai/dsh-{session,agent,llm,commands,timeout}`)
+(`@deepseek-ai/cordis`, `@deepseek-ai/schemastery`, and `@deepseek-ai/dsh-{session,agent,llm,commands,timeout}`)
 are declared as peerDependencies and resolved by the dsh installation's flat
 profile module fallback — no extra install step.
 

--- a/docs/install.zh.md
+++ b/docs/install.zh.md
@@ -16,7 +16,7 @@ dsh plugin --profile web add dsh-advisor   # <name> = 你的 profile 名
 # dsh plugin --profile web add dsh-advisor@0.1.0
 ```
 
-registry 安装拉取的是已发布的 tarball，其中自带构建产物（`lib/` + `cordis.patch.yml`）且没有 `install` / `postinstall` 脚本——不会运行 `prepare` 构建，也无需构建权限。运行时依赖（`@deepseek-ai/cordis`、`schemastery` 与 `@deepseek-ai/dsh-*` peers）声明为 peerDependencies，由 dsh 安装的扁平 profile module fallback 解析——无需额外安装步骤。
+registry 安装拉取的是已发布的 tarball，其中自带构建产物（`lib/` + `cordis.patch.yml`）且没有 `install` / `postinstall` 脚本——不会运行 `prepare` 构建，也无需构建权限。运行时依赖（`@deepseek-ai/cordis`、`@deepseek-ai/schemastery` 与 `@deepseek-ai/dsh-*` peers）声明为 peerDependencies，由 dsh 安装的扁平 profile module fallback 解析——无需额外安装步骤。
 
 - **版本钉住**：追加 `@<version>` 即可（如 `dsh-advisor@0.1.0`）。registry 包没有 commit 钉住；要测试未发布改动，用下面的[本地目录安装](#2-本地目录安装开发--验证)。
 
@@ -36,7 +36,7 @@ pnpm pack
 dsh plugin --profile web add dsh-advisor-0.1.0.tgz
 ```
 
-tarball 附带的是构建产物（`lib/` + `cordis.patch.yml`），因此不会运行 `prepare` 脚本，也无需构建权限。运行时依赖（`@deepseek-ai/cordis`、`schemastery` 与 `@deepseek-ai/dsh-{session,agent,llm,commands,timeout}`）声明为 peerDependencies，由 dsh 安装的扁平 profile module fallback 解析——无需额外安装步骤。
+tarball 附带的是构建产物（`lib/` + `cordis.patch.yml`），因此不会运行 `prepare` 脚本，也无需构建权限。运行时依赖（`@deepseek-ai/cordis`、`@deepseek-ai/schemastery` 与 `@deepseek-ai/dsh-{session,agent,llm,commands,timeout}`）声明为 peerDependencies，由 dsh 安装的扁平 profile module fallback 解析——无需额外安装步骤。
 
 ## 4. web Settings 暴露
 

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.6",
     "@deepseek-ai/dsh-typert-registry": "^0.1.0-rc.6",
     "react": "^18.2.0",
-    "schemastery": "^3.18.0"
+    "@deepseek-ai/schemastery": "^3.18.1"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.1",
@@ -79,7 +79,6 @@
     "lightningcss": "^1.33.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "schemastery": "^3.18.0",
     "typescript": "^5.6.0",
     "vitest": "^3.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       '@deepseek-ai/dsh-typert-registry':
         specifier: ^0.1.0-rc.6
         version: 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/schemastery':
+        specifier: ^3.18.1
+        version: 3.18.1
     devDependencies:
       '@testing-library/dom':
         specifier: ^10.4.1
@@ -96,9 +99,6 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
-      schemastery:
-        specifier: ^3.18.0
-        version: 3.18.0
       typescript:
         specifier: ^5.6.0
         version: 5.9.3
@@ -883,7 +883,6 @@ packages:
     engines: {node: ^22.20 || ^24.12 || >=25}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-android-arm-eabi@4.62.4':
     resolution: {integrity: sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==}
@@ -919,79 +918,66 @@ packages:
     resolution: {integrity: sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.4':
     resolution: {integrity: sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.4':
     resolution: {integrity: sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.62.4':
     resolution: {integrity: sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.4':
     resolution: {integrity: sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.62.4':
     resolution: {integrity: sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.4':
     resolution: {integrity: sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.4':
     resolution: {integrity: sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.4':
     resolution: {integrity: sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.4':
     resolution: {integrity: sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.4':
     resolution: {integrity: sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.4':
     resolution: {integrity: sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.62.4':
     resolution: {integrity: sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.62.4':
     resolution: {integrity: sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==}
@@ -1211,9 +1197,6 @@ packages:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
     engines: {node: '>= 12'}
 
-  cosmokit@1.8.1:
-    resolution: {integrity: sha512-PDBv4l90xZKrUsZ0vtoycgZpO/j4iFsqJXrAxsyBDsnQRI7ZMJXIjgDJsKNjd5L8jnVnnlrDCdhkFbTncgCVjQ==}
-
   css-tree@3.2.1:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
@@ -1375,28 +1358,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.33.0:
     resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.33.0:
     resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.33.0:
     resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.33.0:
     resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
@@ -1649,9 +1628,6 @@ packages:
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
-
-  schemastery@3.18.0:
-    resolution: {integrity: sha512-Jw2uxjoyyqc/yeurmChUEc/jbi8GsrdXV/KmqRUDZXJAXAmrJiPsz8vKa17l/VckyzljHZ9oGaul443CQiXxtA==}
 
   shiki@4.4.3:
     resolution: {integrity: sha512-Mb/GvXPHBAXdgGIcnfU5L3ldpn1XcxrGkPHwqgRx17/I2XRfqlFKk2vGkHWINn1kdXvzJZeuO3is6I9KLPFm0g==}
@@ -2937,8 +2913,6 @@ snapshots:
 
   commander@8.3.0: {}
 
-  cosmokit@1.8.1: {}
-
   css-tree@3.2.1:
     dependencies:
       mdn-data: 2.27.1
@@ -3592,11 +3566,6 @@ snapshots:
   scheduler@0.23.2:
     dependencies:
       loose-envify: 1.4.0
-
-  schemastery@3.18.0:
-    dependencies:
-      '@standard-schema/spec': 1.1.0
-      cosmokit: 1.8.1
 
   shiki@4.4.3:
     dependencies:

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,7 +12,7 @@
  * @module dsh-advisor/config
  */
 
-import z from 'schemastery'
+import z from '@deepseek-ai/schemastery'
 
 /** Raw plugin row config after Loader defaults — spec §5.1. */
 export interface AdvisorConfig {

--- a/tests/peer-deps.test.ts
+++ b/tests/peer-deps.test.ts
@@ -43,6 +43,12 @@ describe('registry peer contract (rc.6 from npm, no link farm)', () => {
     }
   })
 
+  it('uses the scoped schemastery peer supplied by DSH rc.6', () => {
+    expect(root.peerDependencies?.['@deepseek-ai/schemastery']).toBe('^3.18.1')
+    expect(root.peerDependencies?.schemastery).toBeUndefined()
+    expect(root.devDependencies?.schemastery).toBeUndefined()
+  })
+
   it('autoInstallPeers is enabled (registry resolution, no link farm)', () => {
     const workspace = readFileSync(resolve(repo, 'pnpm-workspace.yaml'), 'utf8')
     expect(workspace).toMatch(/autoInstallPeers\s*:\s*true/)


### PR DESCRIPTION
## What

- Import and declare the scoped `@deepseek-ai/schemastery` package shipped by DSH rc.6.
- Remove the unscoped `schemastery` development/runtime expectation.
- Update install documentation and add a peer-contract regression test.

## Why

A fresh DSH `0.1.0-rc.6` Web profile can install `dsh-advisor@0.1.0`, but Host boot then fails with `ERR_MODULE_NOT_FOUND` because the profile fallback provides `@deepseek-ai/schemastery`, not the unscoped package. This blocks the four-plugin Explain M6 composition.

## Checks

- `pnpm run typecheck`
- `pnpm run test` (299 tests)
- `npm pack --dry-run --ignore-scripts`
- DSH rc.6 four-plugin Web composition with Explain, selection-chat, suggested-replies, and this branch (3 acceptance tests)
