### PR TITLE
ci: add CI gate + PR-driven npm release flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,11 @@ jobs:
 
       - name: Assert packed tarball contents
         run: |
-          # npm pack --dry-run prints the Tarball Contents listing; fail the
-          # job if the built entrypoint or the cordis bundle patch is missing.
-          npm pack --dry-run --ignore-scripts | tee "$RUNNER_TEMP/pack-listing.txt"
+          set -euo pipefail
+          # npm pack --dry-run prints the Tarball Contents listing to STDERR on
+          # npm 11 (stdout carries only the tarball filename), so capture both
+          # streams; fail the job if the built entrypoint or the cordis bundle
+          # patch is missing.
+          npm pack --dry-run --ignore-scripts 2>&1 | tee "$RUNNER_TEMP/pack-listing.txt"
           grep -Eq "lib/index\.js( |$)" "$RUNNER_TEMP/pack-listing.txt"
           grep -Eq "cordis\.patch\.yml( |$)" "$RUNNER_TEMP/pack-listing.txt"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # pnpm/action-setup must run before setup-node so that
+      # setup-node's `cache: pnpm` can locate the pnpm store path.
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 11
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm run typecheck
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Test
+        run: pnpm run test
+
+      - name: Assert packed tarball contents
+        run: |
+          # npm pack --dry-run prints the Tarball Contents listing; fail the
+          # job if the built entrypoint or the cordis bundle patch is missing.
+          npm pack --dry-run --ignore-scripts | tee "$RUNNER_TEMP/pack-listing.txt"
+          grep -Eq "lib/index\.js( |$)" "$RUNNER_TEMP/pack-listing.txt"
+          grep -Eq "cordis\.patch\.yml( |$)" "$RUNNER_TEMP/pack-listing.txt"

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -1,0 +1,128 @@
+name: Release prep
+
+# Manual entry point: Actions → "Release prep" → Run workflow (optionally pass
+# an explicit X.Y.Z). Bumps package.json (+ lockfile sync), validates the
+# build, and opens a `release vX.Y.Z` PR. Merging that PR runs the Release
+# workflow, which publishes dsh-advisor@X.Y.Z, pushes tag vX.Y.Z, and creates
+# the GitHub Release.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Target version (e.g. 0.2.0). Leave empty for auto patch bump."
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: release-prep
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Full history so `git describe --tags` can find the previous
+          # release tag (nearest ancestor tag of HEAD).
+          fetch-depth: 0
+
+      # pnpm/action-setup must run before setup-node so that setup-node's
+      # `cache: pnpm` can locate the pnpm store path (same order as ci.yml).
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 11
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Reject already-released version
+        id: want
+        run: |
+          V="${{ inputs.version }}"
+          if [ -z "$V" ]; then V="auto"; fi
+          if [ "$V" != "auto" ] && git rev-parse "v$V" >/dev/null 2>&1; then
+            echo "::error::Tag v$V already exists."
+            exit 1
+          fi
+          echo "version=$V" >> "$GITHUB_OUTPUT"
+
+      - name: Bump version
+        id: ver
+        run: |
+          V="${{ steps.want.outputs.version }}"
+          if [ "$V" = "auto" ]; then
+            OUT="$(node scripts/prepare-release.mjs)"
+          else
+            OUT="$(node scripts/prepare-release.mjs "$V")"
+          fi
+          echo "$OUT"
+          echo "version=${OUT#VERSION=}" >> "$GITHUB_OUTPUT"
+
+      - name: Sync lockfile
+        run: pnpm install --lockfile-only
+
+      - name: Sanity gate (typecheck + build + test)
+        run: |
+          pnpm run typecheck
+          pnpm run build
+          pnpm run test
+
+      - name: Extract release notes
+        run: |
+          # Previous release = nearest ancestor tag of HEAD. Do NOT use
+          # "v$VERSION^": the version string is not a git ref — the bump
+          # commit is not tagged yet, and the ancestor tag is the only
+          # correct base for "commits since the last release".
+          PREV_TAG=$(git describe --tags --abbrev=0 HEAD 2>/dev/null || echo "")
+          git log --oneline --first-parent ${PREV_TAG:+$PREV_TAG..}HEAD > /tmp/notes.md
+          if [ ! -s /tmp/notes.md ]; then
+            echo "No commits between releases." > /tmp/notes.md
+          fi
+
+      - name: Commit prepared release
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          BRANCH="release/v${{ steps.ver.outputs.version }}"
+          git checkout -B "$BRANCH"
+          git add -A
+          git commit -m "chore(release): prepare v${{ steps.ver.outputs.version }}"
+          git push --force-with-lease origin "$BRANCH"
+
+      - name: Ensure release label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh label create release --if-not-exists --color 0E8A16 || true
+
+      - name: Open or update release PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          BRANCH="release/v${VERSION}"
+          TITLE="release v${VERSION}"
+          {
+            cat /tmp/notes.md
+            echo
+            echo "Merging this PR tags v${VERSION} and publishes dsh-advisor@${VERSION} via the Release workflow."
+          } > /tmp/pr-body.md
+          if gh pr view "$BRANCH" >/dev/null 2>&1; then
+            gh pr edit "$BRANCH" --title "$TITLE" --body-file /tmp/pr-body.md
+            echo "Updated existing release PR for $BRANCH"
+          else
+            gh pr create --base main --head "$BRANCH" --title "$TITLE" \
+              --body-file /tmp/pr-body.md --label release
+          fi

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -51,8 +51,16 @@ jobs:
       - name: Reject already-released version
         id: want
         run: |
+          set -euo pipefail
           V="${{ inputs.version }}"
           if [ -z "$V" ]; then V="auto"; fi
+          # First-line guard: validate an explicit input before it is echoed
+          # into GITHUB_OUTPUT or passed to git rev-parse. prepare-release.mjs
+          # still validates downstream; this is defense in depth.
+          if [ "$V" != "auto" ] && ! [[ "$V" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid version input \"$V\". Expected X.Y.Z (e.g. 0.2.0)."
+            exit 1
+          fi
           if [ "$V" != "auto" ] && git rev-parse "v$V" >/dev/null 2>&1; then
             echo "::error::Tag v$V already exists."
             exit 1
@@ -62,6 +70,7 @@ jobs:
       - name: Bump version
         id: ver
         run: |
+          set -euo pipefail
           V="${{ steps.want.outputs.version }}"
           if [ "$V" = "auto" ]; then
             OUT="$(node scripts/prepare-release.mjs)"
@@ -76,12 +85,14 @@ jobs:
 
       - name: Sanity gate (typecheck + build + test)
         run: |
+          set -euo pipefail
           pnpm run typecheck
           pnpm run build
           pnpm run test
 
       - name: Extract release notes
         run: |
+          set -euo pipefail
           # Previous release = nearest ancestor tag of HEAD. Do NOT use
           # "v$VERSION^": the version string is not a git ref — the bump
           # commit is not tagged yet, and the ancestor tag is the only
@@ -94,6 +105,7 @@ jobs:
 
       - name: Commit prepared release
         run: |
+          set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           BRANCH="release/v${{ steps.ver.outputs.version }}"
@@ -112,6 +124,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.ver.outputs.version }}
         run: |
+          set -euo pipefail
           BRANCH="release/v${VERSION}"
           TITLE="release v${VERSION}"
           {
@@ -120,7 +133,12 @@ jobs:
             echo "Merging this PR tags v${VERSION} and publishes dsh-advisor@${VERSION} via the Release workflow."
           } > /tmp/pr-body.md
           if gh pr view "$BRANCH" >/dev/null 2>&1; then
-            gh pr edit "$BRANCH" --title "$TITLE" --body-file /tmp/pr-body.md
+            STATE="$(gh pr view "$BRANCH" --json state --jq .state)"
+            if [ "$STATE" = "CLOSED" ]; then
+              gh pr reopen "$BRANCH"
+              echo "Reopened previously closed release PR for $BRANCH"
+            fi
+            gh pr edit "$BRANCH" --title "$TITLE" --body-file /tmp/pr-body.md --add-label release
             echo "Updated existing release PR for $BRANCH"
           else
             gh pr create --base main --head "$BRANCH" --title "$TITLE" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,123 @@
+name: Release
+
+# PR-driven release. Merging a `release vX.Y.Z` PR (opened by the Release prep
+# workflow) runs the whole release inline on the pull_request event:
+# validate -> sanity gate -> npm publish dsh-advisor@X.Y.Z -> create+push the
+# vX.Y.Z tag (skipped if it already exists) -> GitHub Release.
+#
+# The workflow runs on the merged release PR event, so no secrets are required
+# for the default flow except NPM_TOKEN (npm registry auth for publish). The
+# tag and GitHub Release are created with the workflow's GITHUB_TOKEN.
+#
+# NOTE: publish happens BEFORE tag creation (mirror mstar-harness). If the tag
+# already exists (e.g. a re-run after a partial failure), publish still
+# proceeds and the tag step skips.
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    if: >
+      github.event.pull_request.merged == true
+      && startsWith(github.event.pull_request.title, 'release v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout merge commit
+        uses: actions/checkout@v4
+        with:
+          # Release the exact merge commit of the merged release PR, with full
+          # history so `git describe --tags` can find the previous release tag.
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0
+
+      # pnpm/action-setup must run before setup-node so that setup-node's
+      # `cache: pnpm` can locate the pnpm store path (same order as ci.yml).
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 11
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: https://registry.npmjs.org
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Resolve version
+        id: ver
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Validate version
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          if [ -z "$VERSION" ]; then
+            echo "::error::package.json version is empty; refusing to release."
+            exit 1
+          fi
+          # Tag-exists policy (mirror mstar-harness): publish proceeds even if
+          # v$VERSION already exists (e.g. re-run after a partial failure); the
+          # tag step below skips creation when the tag is already present.
+          echo "Releasing dsh-advisor@${VERSION}"
+
+      - name: Sanity gate (typecheck + build + test)
+        run: |
+          pnpm run typecheck
+          pnpm run build
+          pnpm run test
+
+      # npm auth: setup-node wrote `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}`
+      # into .npmrc; this step supplies the token from the NPM_TOKEN secret.
+      - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Create + push tag
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          set -euo pipefail
+          TAG="v${VERSION}"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists; skipping tag creation."
+            exit 0
+          fi
+          git tag -a -m "Release ${TAG}" "$TAG"
+          git push origin "$TAG"
+
+      - name: Extract release notes
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          # Previous release = nearest ancestor tag of HEAD. Do NOT use
+          # "v$VERSION^": the version string is not a git ref — the bump
+          # commit is not tagged yet, and the ancestor tag is the only
+          # correct base for "commits since the last release".
+          PREV_TAG=$(git describe --tags --abbrev=0 HEAD 2>/dev/null || echo "")
+          git log --oneline --first-parent ${PREV_TAG:+$PREV_TAG..}HEAD > /tmp/notes.md
+          if [ ! -s /tmp/notes.md ]; then
+            echo "No commits between releases." > /tmp/notes.md
+          fi
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.ver.outputs.version }}
+          name: v${{ steps.ver.outputs.version }}
+          body_path: /tmp/notes.md
+          draft: false
+          prerelease: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
     if: >
       github.event.pull_request.merged == true
       && startsWith(github.event.pull_request.title, 'release v')
+      && startsWith(github.event.pull_request.head.ref, 'release/v')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout merge commit
@@ -80,6 +81,17 @@ jobs:
 
       # npm auth: setup-node wrote `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}`
       # into .npmrc; this step supplies the token from the NPM_TOKEN secret.
+      - name: Assert packed tarball contents (pre-publish guard)
+        run: |
+          set -euo pipefail
+          # Same guard as ci.yml: npm 11 writes the Tarball Contents listing to
+          # STDERR (stdout carries only the tarball filename), so capture both
+          # streams; refuse to publish a tarball missing the built entrypoint
+          # or the cordis bundle patch.
+          npm pack --dry-run --ignore-scripts 2>&1 | tee "$RUNNER_TEMP/pack-listing.txt"
+          grep -Eq "lib/index\.js( |$)" "$RUNNER_TEMP/pack-listing.txt"
+          grep -Eq "cordis\.patch\.yml( |$)" "$RUNNER_TEMP/pack-listing.txt"
+
       - name: Publish to npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 jobs:
   release:
     if: >
@@ -86,6 +90,18 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+      - name: Extract release notes
+        run: |
+          # Previous release = nearest ancestor tag of HEAD. Do NOT use
+          # "v$VERSION^": the version string is not a git ref — the bump
+          # commit is not tagged yet, and the ancestor tag is the only
+          # correct base for "commits since the last release".
+          PREV_TAG=$(git describe --tags --abbrev=0 HEAD 2>/dev/null || echo "")
+          git log --oneline --first-parent ${PREV_TAG:+$PREV_TAG..}HEAD > /tmp/notes.md
+          if [ ! -s /tmp/notes.md ]; then
+            echo "No commits between releases." > /tmp/notes.md
+          fi
+
       - name: Create + push tag
         env:
           VERSION: ${{ steps.ver.outputs.version }}
@@ -98,20 +114,6 @@ jobs:
           fi
           git tag -a -m "Release ${TAG}" "$TAG"
           git push origin "$TAG"
-
-      - name: Extract release notes
-        env:
-          VERSION: ${{ steps.ver.outputs.version }}
-        run: |
-          # Previous release = nearest ancestor tag of HEAD. Do NOT use
-          # "v$VERSION^": the version string is not a git ref — the bump
-          # commit is not tagged yet, and the ancestor tag is the only
-          # correct base for "commits since the last release".
-          PREV_TAG=$(git describe --tags --abbrev=0 HEAD 2>/dev/null || echo "")
-          git log --oneline --first-parent ${PREV_TAG:+$PREV_TAG..}HEAD > /tmp/notes.md
-          if [ ! -s /tmp/notes.md ]; then
-            echo "No commits between releases." > /tmp/notes.md
-          fi
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,43 @@
+# 发布指南
+
+本文介绍如何发布新版 `dsh-advisor` 到 npm 并创建 GitHub Release。发布流程是 **PR 驱动**的：先由 **Release prep** 工作流准备版本号并打开 `release vX.Y.Z` PR，合并该 PR 后由 **Release** 工作流自动完成发布、打 tag 与 GitHub Release。安装与卸载见[安装指南](install.zh.md)。
+
+## 前置条件
+
+- **`NPM_TOKEN` secret 必须存在**：Release 工作流通过 `NODE_AUTH_TOKEN` 环境变量（取自仓库 **Settings → Secrets and variables → Actions** 的 `NPM_TOKEN`）向 npm registry 认证。token 缺失或失效时，`npm publish` 会因 401 失败。除 `NPM_TOKEN` 外，默认流程不需要其它 secret——tag 与 GitHub Release 都用工作流自带的 `GITHUB_TOKEN`（需 `contents: write` 权限，Release 工作流已声明）。
+- 仓库启用 GitHub Actions；发布 PR 需通过仓库的分支保护检查（CI 校验 + review）才能合并。
+
+## 1. 发布流程
+
+1. 打开仓库 **Actions** 页，在左侧选择 **Release prep** 工作流。
+2. （可选）在 **Run workflow** 表单的 `version` 输入框填写目标版本号（如 `0.2.0`）；**留空则自动打 patch 版本**（见[版本策略](#3-版本策略)）。
+3. 点击 **Run workflow** 触发发布准备。
+4. 等待 **Release prep** 运行完成：它会把版本号写入 `package.json` 并同步 `pnpm-lock.yaml`，跑一遍 typecheck / build / test 校验，然后创建 `release/vX.Y.Z` 分支并打开标题为 **`release vX.Y.Z`** 的 PR（PR 正文带自上一个 tag 以来的提交记录）。
+5. 合并该 **`release vX.Y.Z`** PR。**合并即发布**——不需要再手动运行任何工作流。
+
+## 2. 合并后自动发生什么
+
+合并 `release vX.Y.Z` PR 后，**Release** 工作流在 `pull_request`（closed）事件上运行，按顺序自动执行：
+
+1. **校验**：检出合并提交（`merge_commit_sha`），读取 `package.json` 版本号并确认非空。
+2. **构建**：`pnpm run typecheck && pnpm run build && pnpm run test`（与 CI 相同的校验命令）。
+3. **发布**：`npm publish --access public`，向 npm 发布 `dsh-advisor@X.Y.Z`（认证走 `NPM_TOKEN` secret）。
+4. **打 tag**：以 `github-actions[bot]` 身份创建并推送注解 tag `vX.Y.Z`（commit message `Release vX.Y.Z`）；若该 tag 已存在（例如发布后重跑工作流），tag 步骤会跳过——发布仍然照常进行。
+5. **创建 GitHub Release**：以 `vX.Y.Z` 为 tag 与标题创建 Release，正文为自上一个 tag 以来的提交记录（`git log --oneline --first-parent`，取最近祖先 tag 为基准）。
+
+## 3. 版本策略
+
+- **留空 = 自动 patch**：`scripts/prepare-release.mjs` 读取当前 `package.json` 版本并把 patch 位 +1（`0.1.0` → `0.1.1` → `0.1.2`…）。
+- **显式 X.Y.Z**：在 `version` 输入框填写完整 semver（如 `0.2.0`、`1.0.0`）。需要 minor / major 升级、或想跳过中间 patch 版本时用这个方式。
+- **重复版本会被拒绝**：若 `vX.Y.Z` 对应的 git tag 已存在（该版本已发布过），Release prep 会直接报错退出，请改填一个新版本号再跑。
+
+## 4. 回滚 / 修正
+
+- **npm 不允许覆盖已发布的版本**：同一 `X.Y.Z` 不能重复 `npm publish`。发布后发现缺陷时，**不要试图重发同版本**——修复后在主分支合并，再走一遍发布流程 bump 出新版本（patch / minor / major 视严重程度）。
+- **yank 需谨慎**：`npm unpublish` / `npm deprecate` 可以下线或废弃某个版本，但会破坏已安装该版本用户的升级路径与依赖解析，只在极端情况（误发、包含敏感信息等）下使用。`npm unpublish` 仅限发布后 72 小时内，且可能影响依赖你的包；`npm deprecate dsh-advisor@X.Y.Z "说明"` 是更温和的标记方式（标记后仍可安装，但会显示弃用警告）。
+- **tag 与 GitHub Release 不会自动删除**：需要时由维护者手动清理（删除远端 tag：`git push origin :refs/tags/vX.Y.Z`，再删除对应 GitHub Release）；但删除 tag 并不会让 npm 上的同版本变为可重发——npm 版本不可覆盖是硬限制。
+
+## 5. 相关文档
+
+- [安装指南](install.zh.md) — registry / 本地目录 / tarball 三种安装方式与卸载
+- [README](../README.zh.md) — 项目概览

--- a/docs/release.md
+++ b/docs/release.md
@@ -22,7 +22,7 @@
 1. **校验**：检出合并提交（`merge_commit_sha`），读取 `package.json` 版本号并确认非空。
 2. **构建**：`pnpm run typecheck && pnpm run build && pnpm run test`（与 CI 相同的校验命令）。
 3. **发布**：`npm publish --access public`，向 npm 发布 `dsh-advisor@X.Y.Z`（认证走 `NPM_TOKEN` secret）。
-4. **打 tag**：以 `github-actions[bot]` 身份创建并推送注解 tag `vX.Y.Z`（commit message `Release vX.Y.Z`）；若该 tag 已存在（例如发布后重跑工作流），tag 步骤会跳过——发布仍然照常进行。
+4. **打 tag**：以 `github-actions[bot]` 身份创建并推送注解 tag `vX.Y.Z`（commit message `Release vX.Y.Z`）；若该 tag 已存在，tag 步骤会跳过。**tag 跳过只覆盖 tag**——npm 不允许重复发布同一版本（`npm error ... previously published versions`），发布成功后重跑工作流会在 `npm publish` 步骤失败，而不是照常发布；仅当 tag 已存在但版本尚未成功发布（例如 tag 推送后、GitHub Release 步骤失败）时，重跑才会继续完成发布。
 5. **创建 GitHub Release**：以 `vX.Y.Z` 为 tag 与标题创建 Release，正文为自上一个 tag 以来的提交记录（`git log --oneline --first-parent`，取最近祖先 tag 为基准）。
 
 ## 3. 版本策略

--- a/docs/release.md
+++ b/docs/release.md
@@ -22,8 +22,8 @@
 1. **校验**：检出合并提交（`merge_commit_sha`），读取 `package.json` 版本号并确认非空。
 2. **构建**：`pnpm run typecheck && pnpm run build && pnpm run test`（与 CI 相同的校验命令）。
 3. **发布**：`npm publish --access public`，向 npm 发布 `dsh-advisor@X.Y.Z`（认证走 `NPM_TOKEN` secret）。
-4. **打 tag**：以 `github-actions[bot]` 身份创建并推送注解 tag `vX.Y.Z`（commit message `Release vX.Y.Z`）；若该 tag 已存在，tag 步骤会跳过。**tag 跳过只覆盖 tag**——npm 不允许重复发布同一版本（`npm error ... previously published versions`），发布成功后重跑工作流会在 `npm publish` 步骤失败，而不是照常发布；仅当 tag 已存在但版本尚未成功发布（例如 tag 推送后、GitHub Release 步骤失败）时，重跑才会继续完成发布。
-5. **创建 GitHub Release**：以 `vX.Y.Z` 为 tag 与标题创建 Release，正文为自上一个 tag 以来的提交记录（`git log --oneline --first-parent`，取最近祖先 tag 为基准）。
+4. **打 tag**：以 `github-actions[bot]` 身份创建并推送注解 tag `vX.Y.Z`（commit message `Release vX.Y.Z`）；若该 tag 已存在，tag 步骤会跳过。**tag 跳过只覆盖 tag**——npm 不允许重复发布同一版本（`npm error ... previously published versions`），因此重跑工作流只在 **`npm publish` 步骤本身失败**（尚未发布任何版本、也未创建 tag）时才能继续完成发布；如果发布已经成功（例如随后 tag 或 GitHub Release 步骤失败），重跑会在 `npm publish` 步骤失败，而不是照常发布。**注意「已发布但未打 tag」的缺口**：发布成功后若 tag 步骤失败，仓库中没有任何 `vX.Y.Z` tag（基于 tag 的重复版本检查也拦不住该版本），此时重跑会卡在 `npm publish`；恢复只能人工处理——用 `gh release create vX.Y.Z --generate-notes`（或 `gh release create` 手动编辑正文）为已发布版本补建 tag 与 GitHub Release，或 bump 一个新版本重新走发布流程。
+5. **创建 GitHub Release**：以 `vX.Y.Z` 为 tag 与标题创建 Release，正文为自上一个 tag 以来的提交记录（`git log --oneline --first-parent`，取最近祖先 tag 为基准）。注意：Release 正文在**合并提交**上提取，会包含 `chore(release): prepare` 提交以及合并前合入的其它提交，因此可能与 PR 正文的发布说明（在 prep 时提取）略有不同——这是设计使然。
 
 ## 3. 版本策略
 

--- a/scripts/prepare-release.mjs
+++ b/scripts/prepare-release.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+/**
+ * Release-prep version helper (plan dsh-advisor-ci-release, task 2):
+ * resolves the target version — explicit `X.Y.Z` argument or an auto patch
+ * bump from package.json — refuses already-released versions (existing
+ * `vX.Y.Z` git tag), bumps package.json, and prints `VERSION=<x.y.z>` for the
+ * workflow to capture. Node built-ins only, no new dependencies.
+ *
+ * Usage:
+ *   node scripts/prepare-release.mjs            # auto patch bump
+ *   node scripts/prepare-release.mjs 0.2.0      # explicit version
+ *
+ * Exit codes: 0 = bumped and printed VERSION; 1 = rejected (unparseable
+ * version, existing tag, or unparseable current package.json version).
+ */
+
+import { execFileSync } from 'node:child_process'
+import { readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+const PKG_PATH = join(REPO_ROOT, 'package.json')
+
+/** Parse strict X.Y.Z (numeric parts only); null when not parseable. */
+function parseVersion(value) {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(value)
+  if (!match) return null
+  return { major: Number(match[1]), minor: Number(match[2]), patch: Number(match[3]) }
+}
+
+const pkg = JSON.parse(readFileSync(PKG_PATH, 'utf8'))
+
+let target
+if (process.argv[2] !== undefined) {
+  target = parseVersion(process.argv[2])
+  if (target === null) {
+    console.error(`Error: invalid version "${process.argv[2]}". Expected X.Y.Z (e.g. 0.2.0).`)
+    process.exit(1)
+  }
+} else {
+  const current = parseVersion(pkg.version)
+  if (current === null) {
+    console.error(`Error: cannot parse current package.json version "${pkg.version}".`)
+    process.exit(1)
+  }
+  target = { major: current.major, minor: current.minor, patch: current.patch + 1 }
+}
+
+const version = `${target.major}.${target.minor}.${target.patch}`
+
+// Reject already-released versions: `git rev-parse vX.Y.Z` succeeds iff the
+// tag exists. Run from REPO_ROOT so the check is cwd-independent.
+try {
+  execFileSync('git', ['rev-parse', `v${version}`], { cwd: REPO_ROOT, stdio: 'ignore' })
+  console.error(`Error: tag v${version} already exists — this version is already released.`)
+  process.exit(1)
+} catch {
+  // Tag absent → OK to prepare.
+}
+
+pkg.version = version
+// Preserve repo formatting: 2-space indent + trailing newline. The version
+// line must be the only diff (verified by `git diff package.json` in the
+// dry-run validation).
+writeFileSync(PKG_PATH, `${JSON.stringify(pkg, null, 2)}\n`, 'utf8')
+
+console.log(`VERSION=${version}`)

--- a/tests/prepare-release.test.ts
+++ b/tests/prepare-release.test.ts
@@ -1,0 +1,111 @@
+/**
+ * CI coverage for scripts/prepare-release.mjs (plan dsh-advisor-ci-release,
+ * QC1 F-004). The script resolves REPO_ROOT from its own file location
+ * (import.meta.url), NOT cwd, so each case runs a COPY of the script inside
+ * a temp fixture: the fixture's package.json is the file the script reads
+ * and bumps, and a fake `git` shim on PATH stands in for `git rev-parse` so
+ * tag existence is controlled without a real git repo or any network.
+ * Deterministic and fast: real node subprocesses, no installs.
+ *
+ * Note: the script wraps its tag check in try/catch and calls process.exit
+ * inside it, so in-process exit stubbing would be swallowed; spawning the
+ * script as a subprocess exercises the real exit semantics instead.
+ */
+import { describe, expect, it } from 'vitest'
+import { spawnSync } from 'node:child_process'
+import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const repo = resolve(here, '..')
+const scriptPath = resolve(repo, 'scripts', 'prepare-release.mjs')
+
+/**
+ * Minimal git stand-in: only `git rev-parse <tag>` is ever invoked. Tags
+ * listed in ../existing-tags.txt "exist" (exit 0, prints a sha); all other
+ * tags fail like an unknown revision (exit 128).
+ */
+const GIT_SHIM = `#!/bin/sh
+if [ "$1" = "rev-parse" ]; then
+  tag="$2"
+  if grep -qx "$tag" "$(dirname "$0")/../existing-tags.txt" 2>/dev/null; then
+    echo "9f2c5d3e4a1b6c7d8e9f0a1b2c3d4e5f6a7b8c9d"
+    exit 0
+  fi
+  echo "fatal: ambiguous argument '$tag': unknown revision or path not in the working tree." >&2
+  exit 128
+fi
+echo "prepare-release.test: unexpected git invocation: $*" >&2
+exit 2
+`
+
+let fixture = ''
+
+function makeFixture(version: string): void {
+  fixture = mkdtempSync(join(tmpdir(), 'prepare-release-'))
+  mkdirSync(join(fixture, 'bin'))
+  mkdirSync(join(fixture, 'scripts'))
+  writeFileSync(
+    join(fixture, 'package.json'),
+    `${JSON.stringify({ name: 'dsh-advisor', version }, null, 2)}\n`,
+    'utf8',
+  )
+  writeFileSync(join(fixture, 'bin', 'git'), GIT_SHIM, { mode: 0o755 })
+  copyFileSync(scriptPath, join(fixture, 'scripts', 'prepare-release.mjs'))
+}
+
+function fixtureVersion(): string {
+  return JSON.parse(readFileSync(join(fixture, 'package.json'), 'utf8')).version as string
+}
+
+function runScript(args: string[], existingTags: string[]): { status: number; stdout: string; stderr: string } {
+  writeFileSync(join(fixture, 'existing-tags.txt'), existingTags.length ? `${existingTags.join('\n')}\n` : '', 'utf8')
+  const result = spawnSync(process.execPath, [join(fixture, 'scripts', 'prepare-release.mjs'), ...args], {
+    cwd: fixture,
+    env: { ...process.env, PATH: `${join(fixture, 'bin')}:${process.env.PATH ?? ''}` },
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  return {
+    status: result.status ?? (result.error ? 1 : 0),
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  }
+}
+
+describe('scripts/prepare-release.mjs', () => {
+  it('auto patch bump: 0.1.0 -> 0.1.1, prints VERSION=0.1.1, exits 0', () => {
+    makeFixture('0.1.0')
+    const { status, stdout, stderr } = runScript([], [])
+    expect(status).toBe(0)
+    expect(stdout.trim()).toBe('VERSION=0.1.1')
+    expect(stderr).toBe('')
+    expect(fixtureVersion()).toBe('0.1.1')
+  })
+
+  it('explicit version 0.2.0 is accepted and written', () => {
+    makeFixture('0.1.0')
+    const { status, stdout } = runScript(['0.2.0'], [])
+    expect(status).toBe(0)
+    expect(stdout.trim()).toBe('VERSION=0.2.0')
+    expect(fixtureVersion()).toBe('0.2.0')
+  })
+
+  it('invalid explicit version is rejected: exit 1 + stderr message, package.json untouched', () => {
+    makeFixture('0.1.0')
+    const { status, stderr } = runScript(['0.2'], [])
+    expect(status).toBe(1)
+    expect(stderr).toContain('invalid version')
+    expect(fixtureVersion()).toBe('0.1.0')
+  })
+
+  it('existing tag is rejected: exit 1 + stderr message, package.json untouched', () => {
+    makeFixture('0.1.0')
+    const { status, stderr } = runScript([], ['v0.1.1'])
+    expect(status).toBe(1)
+    expect(stderr).toContain('already exists')
+    expect(fixtureVersion()).toBe('0.1.0')
+  })
+})


### PR DESCRIPTION
## What

Morning Star plan `dsh-advisor-ci-release` (ops): CI gate + PR-driven npm publish flow mirroring mstar-harness.

- **ci.yml**: typecheck + build + vitest (299) + npm pack dry-run with tarball assertions (lib/index.js + cordis.patch.yml) on every PR + main push (pnpm 11, Node 24, frozen-lockfile)
- **release-prep.yml** + **scripts/prepare-release.mjs**: workflow_dispatch (optional version, auto patch default) → version bump → validate → `release vX.Y.Z` PR with git-log release notes
- **release.yml**: merged `release v*` PR → validate → build → npm publish (NPM_TOKEN) → tag vX.Y.Z → GitHub Release
- **docs/release.md**: Chinese runbook

## Checks

- actionlint clean (all 3 workflows)
- typecheck / build / 299 tests pass on branch
- `npm publish --dry-run` clean (0.1.0 already-released guard fired as expected)
- SDD task reviews: T1 Approve, T2 Approve, T3 Approve after fix wave (notes-before-tag ordering fix)
- CI on this PR is the self-proof of the new gate

## Plan

.mstar/plans/dsh-advisor-ci-release.md (gitignored harness process artifact)