### PR TITLE
fix: create release label without unsupported --if-not-exists

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -117,7 +117,12 @@ jobs:
       - name: Ensure release label
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh label create release --if-not-exists --color 0E8A16 || true
+        run: |
+          # gh CLI has no --if-not-exists on label create (run 31790422779:
+          # 'unknown flag' swallowed by || true → label missing → pr create fails).
+          # Create, or edit the existing label; fail loudly on both.
+          gh label create release --color 0E8A16 --description "Release PRs" 2>/dev/null \
+            || gh label edit release --color 0E8A16 --description "Release PRs"
 
       - name: Open or update release PR
         env:


### PR DESCRIPTION
## What

Hotfix for release-prep failure (run 31790422779): the 'Ensure release label' step used `gh label create release --if-not-exists` — unsupported flag on gh v2.96 (confirmed: 'unknown flag' in run log), swallowed by `|| true`, so the `release` label never existed and `gh pr create --label release` failed with 'could not add label: release not found'.

## Change

Replace with fail-loud create-or-edit (no `|| true`):
- `gh label create release --color 0E8A16 --description "Release PRs" 2>/dev/null || gh label edit release --color 0E8A16 --description "Release PRs"`

## Checks

- actionlint exit 0
- gh label create --help has no --if-not-exists (v2.96.0)
- Single file change; CI gate on this PR is the proof