### PR TITLE
fix: use PAT for release PR creation (org blocks Actions PRs)

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -116,7 +116,9 @@ jobs:
 
       - name: Ensure release label
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Org blocks Actions-created PRs (createPullRequest GraphQL error);
+          # PAT bypasses. Label + PR steps need PAT, not GITHUB_TOKEN.
+          GH_TOKEN: ${{ secrets.PAT }}
         run: |
           # gh CLI has no --if-not-exists on label create (run 31790422779:
           # 'unknown flag' swallowed by || true → label missing → pr create fails).
@@ -126,7 +128,9 @@ jobs:
 
       - name: Open or update release PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Same as label step: org blocks Actions-created PRs
+          # (createPullRequest GraphQL error); PAT bypasses.
+          GH_TOKEN: ${{ secrets.PAT }}
           VERSION: ${{ steps.ver.outputs.version }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
## What

Second layer of the release-prep failure: after the label fix (PR #19), rerun 31791087243 failed with `GraphQL: GitHub Actions is not permitted to create or approve pull requests (createPullRequest)` — the org blocks Actions-created PRs via GITHUB_TOKEN.

## Change

Switch the two PR-related steps (`Ensure release label` + `Open or update release PR`) from `secrets.GITHUB_TOKEN` to `secrets.PAT` (repo secret added 2026-08-14). Branch push stays on the built-in token (push is permitted; only createPullRequest is blocked).

## Checks

- actionlint exit 0
- No remaining `secrets.GITHUB_TOKEN` in release-prep.yml
- End-to-end proof: rerun Release prep after merge → release v0.1.1 PR opens