### PR TITLE
feat: generate CHANGELOG.md from git log in release-prep

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -93,14 +93,30 @@ jobs:
       - name: Extract release notes
         run: |
           set -euo pipefail
-          # Previous release = nearest ancestor tag of HEAD. Do NOT use
-          # "v$VERSION^": the version string is not a git ref — the bump
-          # commit is not tagged yet, and the ancestor tag is the only
-          # correct base for "commits since the last release".
-          PREV_TAG=$(git describe --tags --abbrev=0 HEAD 2>/dev/null || echo "")
-          git log --oneline --first-parent ${PREV_TAG:+$PREV_TAG..}HEAD > /tmp/notes.md
+          # PR body source: the `## [<version>]` section of CHANGELOG.md,
+          # written by the Bump version step above (prepare-release.mjs) and
+          # committed in this release PR. Same guarded extraction as the
+          # Release workflow, so the PR body and the GitHub Release body are
+          # byte-identical (both = the CHANGELOG section). Guard on the file
+          # existing: under `set -e`, awk on a missing CHANGELOG.md exits 2
+          # and aborts the step before the fallback could run.
+          # Fall back to git log (nearest ancestor tag of HEAD, full history
+          # when no tag exists) only when the file or the section is missing,
+          # e.g. a release PR prepared before CHANGELOG.md existed.
+          VERSION="${{ steps.ver.outputs.version }}"
+          if [ -f CHANGELOG.md ]; then
+            awk -v v="$VERSION" '
+              /^## \[/ { if (in_section) exit }
+              $0 ~ "^## \\[" v "\\]" { in_section = 1 }
+              in_section
+            ' CHANGELOG.md > /tmp/notes.md
+          fi
           if [ ! -s /tmp/notes.md ]; then
-            echo "No commits between releases." > /tmp/notes.md
+            PREV_TAG=$(git describe --tags --abbrev=0 HEAD 2>/dev/null || echo "")
+            git log --oneline --first-parent ${PREV_TAG:+$PREV_TAG..}HEAD > /tmp/notes.md
+            if [ ! -s /tmp/notes.md ]; then
+              echo "No commits between releases." > /tmp/notes.md
+            fi
           fi
 
       - name: Commit prepared release

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -107,7 +107,13 @@ jobs:
           # e.g. a release PR prepared before CHANGELOG.md existed.
           VERSION="${{ steps.ver.outputs.version }}"
           if [ -f CHANGELOG.md ]; then
+            # Escape regex metacharacters in the version inside awk (the gsub
+            # runs after `-v` argument escape processing, which would strip
+            # backslashes from a shell-escaped value) so the anchor matches
+            # literally: dots must not act as any-char. VERSION is strict
+            # X.Y.Z upstream, so only dots are ever present.
             awk -v v="$VERSION" '
+              BEGIN { gsub(/\./, "\\\\&", v) }
               /^## \[/ { if (in_section) exit }
               $0 ~ "^## \\[" v "\\]" { in_section = 1 }
               in_section

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -96,10 +96,12 @@ jobs:
           # PR body source: the `## [<version>]` section of CHANGELOG.md,
           # written by the Bump version step above (prepare-release.mjs) and
           # committed in this release PR. Same guarded extraction as the
-          # Release workflow, so the PR body and the GitHub Release body are
-          # byte-identical (both = the CHANGELOG section). Guard on the file
-          # existing: under `set -e`, awk on a missing CHANGELOG.md exits 2
-          # and aborts the step before the fallback could run.
+          # Release workflow, so the PR body and the GitHub Release body
+          # share the same extraction source (the same CHANGELOG section);
+          # the PR body additionally appends a merge-instruction line when
+          # the PR is opened below. Guard on the file existing: under
+          # `set -e`, awk on a missing CHANGELOG.md exits 2 and aborts the
+          # step before the fallback could run.
           # Fall back to git log (nearest ancestor tag of HEAD, full history
           # when no tag exists) only when the file or the section is missing,
           # e.g. a release PR prepared before CHANGELOG.md existed.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,14 @@ jobs:
             echo "::error::package.json version is empty; refusing to release."
             exit 1
           fi
+          # Strict X.Y.Z guard (mirror release-prep): the version flows into
+          # an awk regex anchor below; reject metacharacters up front so a
+          # malformed package.json version cannot break the extraction (awk
+          # exit-2) after publish.
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid version \"$VERSION\" in package.json. Expected X.Y.Z."
+            exit 1
+          fi
           # Tag-exists policy (mirror mstar-harness): publish proceeds even if
           # v$VERSION already exists (e.g. re-run after a partial failure); the
           # tag step below skips creation when the tag is already present.
@@ -117,7 +125,13 @@ jobs:
           # e.g. a release PR prepared before CHANGELOG.md existed.
           VERSION="${{ steps.ver.outputs.version }}"
           if [ -f CHANGELOG.md ]; then
+            # Escape regex metacharacters in the version inside awk (the gsub
+            # runs after `-v` argument escape processing, which would strip
+            # backslashes from a shell-escaped value) so the anchor matches
+            # literally: dots must not act as any-char. VERSION is strict
+            # X.Y.Z upstream, so only dots are ever present.
             awk -v v="$VERSION" '
+              BEGIN { gsub(/\./, "\\\\&", v) }
               /^## \[/ { if (in_section) exit }
               $0 ~ "^## \\[" v "\\]" { in_section = 1 }
               in_section

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,15 +108,21 @@ jobs:
           # Release body source: the `## [<version>]` section of CHANGELOG.md,
           # written by prepare-release.mjs during release-prep and committed in
           # the release PR — so the GitHub Release body matches the PR body.
+          # Guard on the file existing: under `set -e`, awk on a missing
+          # CHANGELOG.md exits 2 and aborts the step before the fallback could
+          # run. The version anchor is prefix-safe: the pattern is anchored at
+          # `^## \[<version>\]`, so `0.1.1` cannot match a `## [0.1.10]` header.
           # Fall back to git log (nearest ancestor tag of HEAD, full history
-          # when no tag exists) only when the section is missing, e.g. a
-          # release PR prepared before CHANGELOG.md existed.
+          # when no tag exists) only when the file or the section is missing,
+          # e.g. a release PR prepared before CHANGELOG.md existed.
           VERSION="${{ steps.ver.outputs.version }}"
-          awk -v v="$VERSION" '
-            /^## \[/ { if (in_section) exit }
-            $0 ~ "^## \\[" v "\\]" { in_section = 1 }
-            in_section
-          ' CHANGELOG.md > /tmp/notes.md
+          if [ -f CHANGELOG.md ]; then
+            awk -v v="$VERSION" '
+              /^## \[/ { if (in_section) exit }
+              $0 ~ "^## \\[" v "\\]" { in_section = 1 }
+              in_section
+            ' CHANGELOG.md > /tmp/notes.md
+          fi
           if [ ! -s /tmp/notes.md ]; then
             PREV_TAG=$(git describe --tags --abbrev=0 HEAD 2>/dev/null || echo "")
             git log --oneline --first-parent ${PREV_TAG:+$PREV_TAG..}HEAD > /tmp/notes.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,14 +104,25 @@ jobs:
 
       - name: Extract release notes
         run: |
-          # Previous release = nearest ancestor tag of HEAD. Do NOT use
-          # "v$VERSION^": the version string is not a git ref — the bump
-          # commit is not tagged yet, and the ancestor tag is the only
-          # correct base for "commits since the last release".
-          PREV_TAG=$(git describe --tags --abbrev=0 HEAD 2>/dev/null || echo "")
-          git log --oneline --first-parent ${PREV_TAG:+$PREV_TAG..}HEAD > /tmp/notes.md
+          set -euo pipefail
+          # Release body source: the `## [<version>]` section of CHANGELOG.md,
+          # written by prepare-release.mjs during release-prep and committed in
+          # the release PR — so the GitHub Release body matches the PR body.
+          # Fall back to git log (nearest ancestor tag of HEAD, full history
+          # when no tag exists) only when the section is missing, e.g. a
+          # release PR prepared before CHANGELOG.md existed.
+          VERSION="${{ steps.ver.outputs.version }}"
+          awk -v v="$VERSION" '
+            /^## \[/ { if (in_section) exit }
+            $0 ~ "^## \\[" v "\\]" { in_section = 1 }
+            in_section
+          ' CHANGELOG.md > /tmp/notes.md
           if [ ! -s /tmp/notes.md ]; then
-            echo "No commits between releases." > /tmp/notes.md
+            PREV_TAG=$(git describe --tags --abbrev=0 HEAD 2>/dev/null || echo "")
+            git log --oneline --first-parent ${PREV_TAG:+$PREV_TAG..}HEAD > /tmp/notes.md
+            if [ ! -s /tmp/notes.md ]; then
+              echo "No commits between releases." > /tmp/notes.md
+            fi
           fi
 
       - name: Create + push tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+All notable changes to dsh-advisor are documented here. Generated from git log by the release-prep workflow.
+
+## [0.1.0] - 2026-08-13
+
+- 9d293c0 Merge pull request #16 from dsh-external/chore/release-0.1.0
+- af86f22 Merge pull request #15 from dsh-external/chore/deps-bump-rc3
+- 068c511 Merge pull request #14 from dsh-external/fix/gateway-typert-explicit-registration
+- 4f1771a Merge pull request #13 from dsh-external/chore/registry-rc5-peers
+- 90909f6 Merge pull request #12 from dsh-external/fix/dsh-rc2-rename-migration
+- dd2ae3b fix(install): guard host-profile installs and pin virtual-store react identity
+- 294aff1 docs(knowledge): compound pnpm 11 install lessons from PR #11
+- 1b91d10 Merge pull request #11 from dsh-external/fix/windows-pnpm11-install
+- 3fa42f8 fix(docs): swap screenshot contents — settings card vs injected note were reversed
+- c2d93c1 docs(readme): move Settings-page screenshot to the top of the Config section
+- aa763d2 docs(readme): use relative screenshot paths (private repo — raw URLs need auth)
+- e436d84 docs(readme): add Advisor settings-card and injected-note screenshots (hosted on gh raw)
+- 04024de Merge pull request #10 from dsh-external/iteration/iter-20260811-dsh-advisor-ux
+- c6e095a Merge pull request #9 from dsh-external/iteration/iter-20260811-dsh-advisor-n6
+- d292ed6 chore: update gitignore
+- 6280963 refactor: migrate cordis package references to @deepseek-ai/cordis
+- 4dac052 fix(compat): dsh 20260811 snapshot compatibility — advisor plugin tree load
+- b0b4e20 docs(client): correct section docstring — notice covers channel unreachability, not no-settings-service (qc2 M-1)
+- f3007e3 Merge pull request #8 from dsh-external/iteration/iter-20260810-dsh-advisor-n5
+- 7e20c6a fix(settings): drop non-existent exposeToWebClients — upstream has no opt-in
+- a1767a4 Merge pull request #7 from dsh-external/iteration/iter-20260810-dsh-advisor-patch-retirement
+- 6a0a37e chore: update npmrc
+- 7e11da5 chore: update npmrc
+- 70c7a03 Merge pull request #6 from dsh-external/iteration/iter-20260810-dsh-advisor-n4
+- 10268f6 Merge pull request #5 from dsh-external/iteration/iter-20260810-dsh-advisor-n3
+- 8073b34 Merge pull request #4 from dsh-external/iteration/iter-20260810-dsh-advisor-host-fix
+- 7caf7e1 docs: use deepseek-official / deepseek-v4-flash in config example
+- 99a0e19 docs: streamline install section and use web profile in examples
+- 804af27 docs: use static shields badges in READMEs
+- b05ee44 refactor(dev): link real dsh packages via DSH_HOME instead of peer-stubs (#3)
+- 10b231f Merge pull request #2 from dsh-external/iteration/iter-20260810-dsh-advisor-n2
+- 3d4adfb feat: dsh advisor plugin — core single-advisor MVP (omp port) (#1)
+- 2975cb6 Initial commit

--- a/docs/release.md
+++ b/docs/release.md
@@ -23,7 +23,7 @@
 2. **构建**：`pnpm run typecheck && pnpm run build && pnpm run test`（与 CI 相同的校验命令）。
 3. **发布**：`npm publish --access public`，向 npm 发布 `dsh-advisor@X.Y.Z`（认证走 `NPM_TOKEN` secret）。
 4. **打 tag**：以 `github-actions[bot]` 身份创建并推送注解 tag `vX.Y.Z`（commit message `Release vX.Y.Z`）；若该 tag 已存在，tag 步骤会跳过。**tag 跳过只覆盖 tag**——npm 不允许重复发布同一版本（`npm error ... previously published versions`），因此重跑工作流只在 **`npm publish` 步骤本身失败**（尚未发布任何版本、也未创建 tag）时才能继续完成发布；如果发布已经成功（例如随后 tag 或 GitHub Release 步骤失败），重跑会在 `npm publish` 步骤失败，而不是照常发布。**注意「已发布但未打 tag」的缺口**：发布成功后若 tag 步骤失败，仓库中没有任何 `vX.Y.Z` tag（基于 tag 的重复版本检查也拦不住该版本），此时重跑会卡在 `npm publish`；恢复只能人工处理——用 `gh release create vX.Y.Z --generate-notes`（或 `gh release create` 手动编辑正文）为已发布版本补建 tag 与 GitHub Release，或 bump 一个新版本重新走发布流程。
-5. **创建 GitHub Release**：以 `vX.Y.Z` 为 tag 与标题创建 Release，正文取自 `CHANGELOG.md` 中对应版本的 `## [X.Y.Z]` 小节（该小节由 **Release prep** 写入并随发布 PR 提交），仅包含该小节本身；PR 正文取自同一小节（提取来源相同），并额外附一行合并说明（见 [§1 步骤 4](#1-发布流程)）。若该小节缺失（例如在引入 `CHANGELOG.md` 之前准备的旧发布 PR），则回退为自上一个 tag 以来的提交记录（`git log --oneline --first-parent`，取最近祖先 tag 为基准；无 tag 时为完整历史）。
+5. **创建 GitHub Release**：以 `vX.Y.Z` 为 tag 与标题创建 Release，正文取自 `CHANGELOG.md` 中对应版本的 `## [X.Y.Z]` 小节（该小节由 **Release prep** 写入并随发布 PR 提交），仅包含该小节本身；PR 正文取自同一小节（提取来源相同），并额外附一行合并说明（见 [§1 步骤 4](#1-发布流程)）。若该小节缺失（例如在引入 `CHANGELOG.md` 之前准备的旧发布 PR），则回退为自上一个 tag 以来的提交记录（`git log --oneline --first-parent`，取最近祖先 tag 为基准；无 tag 时为完整历史）。注：在 `CHANGELOG.md` 引入之前就已打开的在途发布 PR（例如本次变更时在途的 0.1.1 PR）合并后，其 Release 正文经回退逻辑以 git-log 格式生成，且该版本不会在 `CHANGELOG.md` 中留下小节（同版本不可重复准备）；从下一个版本起，Release 正文恢复为对应 `## [X.Y.Z]` 小节。
 
 ## 3. 版本策略
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,6 +1,6 @@
 # 发布指南
 
-本文介绍如何发布新版 `dsh-advisor` 到 npm 并创建 GitHub Release。发布流程是 **PR 驱动**的：先由 **Release prep** 工作流准备版本号、自动生成 `CHANGELOG.md` 并打开 `release vX.Y.Z` PR（CHANGELOG 随该 PR 一起提交），合并该 PR 后由 **Release** 工作流自动完成发布、打 tag 与 GitHub Release（PR 正文与 Release 正文都取自已提交的 `CHANGELOG.md` 对应小节，两者同源）。安装与卸载见[安装指南](install.zh.md)。
+本文介绍如何发布新版 `dsh-advisor` 到 npm 并创建 GitHub Release。发布流程是 **PR 驱动**的：先由 **Release prep** 工作流准备版本号、自动生成 `CHANGELOG.md` 并打开 `release vX.Y.Z` PR（CHANGELOG 随该 PR 一起提交），合并该 PR 后由 **Release** 工作流自动完成发布、打 tag 与 GitHub Release（PR 正文与 Release 正文同源于已提交的 `CHANGELOG.md` 对应小节：PR 正文为该小节并附一行合并说明，Release 正文仅含该小节）。安装与卸载见[安装指南](install.zh.md)。
 
 ## 前置条件
 
@@ -12,7 +12,7 @@
 1. 打开仓库 **Actions** 页，在左侧选择 **Release prep** 工作流。
 2. （可选）在 **Run workflow** 表单的 `version` 输入框填写目标版本号（如 `0.2.0`）；**留空则自动打 patch 版本**（见[版本策略](#3-版本策略)）。
 3. 点击 **Run workflow** 触发发布准备。
-4. 等待 **Release prep** 运行完成：它会把版本号写入 `package.json` 并同步 `pnpm-lock.yaml`，把自上一个 tag 以来的提交记录以 `## [X.Y.Z]` 小节写入 `CHANGELOG.md`（自动生成，已有小节保持不变；重复运行同一版本不会重复写入），跑一遍 typecheck / build / test 校验，然后创建 `release/vX.Y.Z` 分支并打开标题为 **`release vX.Y.Z`** 的 PR（PR 正文即 `CHANGELOG.md` 中该版本的 `## [X.Y.Z]` 小节，与合并后 GitHub Release 正文同源、内容一致；CHANGELOG 随提交一起进入该 PR）。
+4. 等待 **Release prep** 运行完成：它会把版本号写入 `package.json` 并同步 `pnpm-lock.yaml`，把自上一个 tag 以来的提交记录以 `## [X.Y.Z]` 小节写入 `CHANGELOG.md`（自动生成，已有小节保持不变；重复运行同一版本不会重复写入），跑一遍 typecheck / build / test 校验，然后创建 `release/vX.Y.Z` 分支并打开标题为 **`release vX.Y.Z`** 的 PR（PR 正文 = `CHANGELOG.md` 中该版本的 `## [X.Y.Z]` 小节 + 一行合并说明；合并后 GitHub Release 正文仅取同一小节、不含合并说明——两者提取来源相同；CHANGELOG 随提交一起进入该 PR）。
 5. 合并该 **`release vX.Y.Z`** PR。**合并即发布**——不需要再手动运行任何工作流。
 
 ## 2. 合并后自动发生什么
@@ -23,7 +23,7 @@
 2. **构建**：`pnpm run typecheck && pnpm run build && pnpm run test`（与 CI 相同的校验命令）。
 3. **发布**：`npm publish --access public`，向 npm 发布 `dsh-advisor@X.Y.Z`（认证走 `NPM_TOKEN` secret）。
 4. **打 tag**：以 `github-actions[bot]` 身份创建并推送注解 tag `vX.Y.Z`（commit message `Release vX.Y.Z`）；若该 tag 已存在，tag 步骤会跳过。**tag 跳过只覆盖 tag**——npm 不允许重复发布同一版本（`npm error ... previously published versions`），因此重跑工作流只在 **`npm publish` 步骤本身失败**（尚未发布任何版本、也未创建 tag）时才能继续完成发布；如果发布已经成功（例如随后 tag 或 GitHub Release 步骤失败），重跑会在 `npm publish` 步骤失败，而不是照常发布。**注意「已发布但未打 tag」的缺口**：发布成功后若 tag 步骤失败，仓库中没有任何 `vX.Y.Z` tag（基于 tag 的重复版本检查也拦不住该版本），此时重跑会卡在 `npm publish`；恢复只能人工处理——用 `gh release create vX.Y.Z --generate-notes`（或 `gh release create` 手动编辑正文）为已发布版本补建 tag 与 GitHub Release，或 bump 一个新版本重新走发布流程。
-5. **创建 GitHub Release**：以 `vX.Y.Z` 为 tag 与标题创建 Release，正文取自 `CHANGELOG.md` 中对应版本的 `## [X.Y.Z]` 小节（该小节由 **Release prep** 写入并随发布 PR 提交），与 PR 正文（同为该小节）内容一致。若该小节缺失（例如在引入 `CHANGELOG.md` 之前准备的旧发布 PR），则回退为自上一个 tag 以来的提交记录（`git log --oneline --first-parent`，取最近祖先 tag 为基准；无 tag 时为完整历史）。
+5. **创建 GitHub Release**：以 `vX.Y.Z` 为 tag 与标题创建 Release，正文取自 `CHANGELOG.md` 中对应版本的 `## [X.Y.Z]` 小节（该小节由 **Release prep** 写入并随发布 PR 提交），仅包含该小节本身；PR 正文取自同一小节（提取来源相同），并额外附一行合并说明（见 [§1 步骤 4](#1-发布流程)）。若该小节缺失（例如在引入 `CHANGELOG.md` 之前准备的旧发布 PR），则回退为自上一个 tag 以来的提交记录（`git log --oneline --first-parent`，取最近祖先 tag 为基准；无 tag 时为完整历史）。
 
 ## 3. 版本策略
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,6 +1,6 @@
 # 发布指南
 
-本文介绍如何发布新版 `dsh-advisor` 到 npm 并创建 GitHub Release。发布流程是 **PR 驱动**的：先由 **Release prep** 工作流准备版本号、自动生成 `CHANGELOG.md` 并打开 `release vX.Y.Z` PR（CHANGELOG 随该 PR 一起提交），合并该 PR 后由 **Release** 工作流自动完成发布、打 tag 与 GitHub Release（Release 正文取自已提交的 `CHANGELOG.md` 对应小节）。安装与卸载见[安装指南](install.zh.md)。
+本文介绍如何发布新版 `dsh-advisor` 到 npm 并创建 GitHub Release。发布流程是 **PR 驱动**的：先由 **Release prep** 工作流准备版本号、自动生成 `CHANGELOG.md` 并打开 `release vX.Y.Z` PR（CHANGELOG 随该 PR 一起提交），合并该 PR 后由 **Release** 工作流自动完成发布、打 tag 与 GitHub Release（PR 正文与 Release 正文都取自已提交的 `CHANGELOG.md` 对应小节，两者同源）。安装与卸载见[安装指南](install.zh.md)。
 
 ## 前置条件
 
@@ -12,7 +12,7 @@
 1. 打开仓库 **Actions** 页，在左侧选择 **Release prep** 工作流。
 2. （可选）在 **Run workflow** 表单的 `version` 输入框填写目标版本号（如 `0.2.0`）；**留空则自动打 patch 版本**（见[版本策略](#3-版本策略)）。
 3. 点击 **Run workflow** 触发发布准备。
-4. 等待 **Release prep** 运行完成：它会把版本号写入 `package.json` 并同步 `pnpm-lock.yaml`，把自上一个 tag 以来的提交记录以 `## [X.Y.Z]` 小节写入 `CHANGELOG.md`（自动生成，已有小节保持不变；重复运行同一版本不会重复写入），跑一遍 typecheck / build / test 校验，然后创建 `release/vX.Y.Z` 分支并打开标题为 **`release vX.Y.Z`** 的 PR（PR 正文带相同的提交记录，CHANGELOG 随提交一起进入该 PR）。
+4. 等待 **Release prep** 运行完成：它会把版本号写入 `package.json` 并同步 `pnpm-lock.yaml`，把自上一个 tag 以来的提交记录以 `## [X.Y.Z]` 小节写入 `CHANGELOG.md`（自动生成，已有小节保持不变；重复运行同一版本不会重复写入），跑一遍 typecheck / build / test 校验，然后创建 `release/vX.Y.Z` 分支并打开标题为 **`release vX.Y.Z`** 的 PR（PR 正文即 `CHANGELOG.md` 中该版本的 `## [X.Y.Z]` 小节，与合并后 GitHub Release 正文同源、内容一致；CHANGELOG 随提交一起进入该 PR）。
 5. 合并该 **`release vX.Y.Z`** PR。**合并即发布**——不需要再手动运行任何工作流。
 
 ## 2. 合并后自动发生什么
@@ -23,7 +23,7 @@
 2. **构建**：`pnpm run typecheck && pnpm run build && pnpm run test`（与 CI 相同的校验命令）。
 3. **发布**：`npm publish --access public`，向 npm 发布 `dsh-advisor@X.Y.Z`（认证走 `NPM_TOKEN` secret）。
 4. **打 tag**：以 `github-actions[bot]` 身份创建并推送注解 tag `vX.Y.Z`（commit message `Release vX.Y.Z`）；若该 tag 已存在，tag 步骤会跳过。**tag 跳过只覆盖 tag**——npm 不允许重复发布同一版本（`npm error ... previously published versions`），因此重跑工作流只在 **`npm publish` 步骤本身失败**（尚未发布任何版本、也未创建 tag）时才能继续完成发布；如果发布已经成功（例如随后 tag 或 GitHub Release 步骤失败），重跑会在 `npm publish` 步骤失败，而不是照常发布。**注意「已发布但未打 tag」的缺口**：发布成功后若 tag 步骤失败，仓库中没有任何 `vX.Y.Z` tag（基于 tag 的重复版本检查也拦不住该版本），此时重跑会卡在 `npm publish`；恢复只能人工处理——用 `gh release create vX.Y.Z --generate-notes`（或 `gh release create` 手动编辑正文）为已发布版本补建 tag 与 GitHub Release，或 bump 一个新版本重新走发布流程。
-5. **创建 GitHub Release**：以 `vX.Y.Z` 为 tag 与标题创建 Release，正文取自 `CHANGELOG.md` 中对应版本的 `## [X.Y.Z]` 小节（该小节由 **Release prep** 写入并随发布 PR 提交），因此与 PR 正文的发布说明一致。若该小节缺失（例如在引入 `CHANGELOG.md` 之前准备的旧发布 PR），则回退为自上一个 tag 以来的提交记录（`git log --oneline --first-parent`，取最近祖先 tag 为基准；无 tag 时为完整历史）。
+5. **创建 GitHub Release**：以 `vX.Y.Z` 为 tag 与标题创建 Release，正文取自 `CHANGELOG.md` 中对应版本的 `## [X.Y.Z]` 小节（该小节由 **Release prep** 写入并随发布 PR 提交），与 PR 正文（同为该小节）内容一致。若该小节缺失（例如在引入 `CHANGELOG.md` 之前准备的旧发布 PR），则回退为自上一个 tag 以来的提交记录（`git log --oneline --first-parent`，取最近祖先 tag 为基准；无 tag 时为完整历史）。
 
 ## 3. 版本策略
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,6 +1,6 @@
 # 发布指南
 
-本文介绍如何发布新版 `dsh-advisor` 到 npm 并创建 GitHub Release。发布流程是 **PR 驱动**的：先由 **Release prep** 工作流准备版本号并打开 `release vX.Y.Z` PR，合并该 PR 后由 **Release** 工作流自动完成发布、打 tag 与 GitHub Release。安装与卸载见[安装指南](install.zh.md)。
+本文介绍如何发布新版 `dsh-advisor` 到 npm 并创建 GitHub Release。发布流程是 **PR 驱动**的：先由 **Release prep** 工作流准备版本号、自动生成 `CHANGELOG.md` 并打开 `release vX.Y.Z` PR（CHANGELOG 随该 PR 一起提交），合并该 PR 后由 **Release** 工作流自动完成发布、打 tag 与 GitHub Release（Release 正文取自已提交的 `CHANGELOG.md` 对应小节）。安装与卸载见[安装指南](install.zh.md)。
 
 ## 前置条件
 
@@ -12,7 +12,7 @@
 1. 打开仓库 **Actions** 页，在左侧选择 **Release prep** 工作流。
 2. （可选）在 **Run workflow** 表单的 `version` 输入框填写目标版本号（如 `0.2.0`）；**留空则自动打 patch 版本**（见[版本策略](#3-版本策略)）。
 3. 点击 **Run workflow** 触发发布准备。
-4. 等待 **Release prep** 运行完成：它会把版本号写入 `package.json` 并同步 `pnpm-lock.yaml`，跑一遍 typecheck / build / test 校验，然后创建 `release/vX.Y.Z` 分支并打开标题为 **`release vX.Y.Z`** 的 PR（PR 正文带自上一个 tag 以来的提交记录）。
+4. 等待 **Release prep** 运行完成：它会把版本号写入 `package.json` 并同步 `pnpm-lock.yaml`，把自上一个 tag 以来的提交记录以 `## [X.Y.Z]` 小节写入 `CHANGELOG.md`（自动生成，已有小节保持不变；重复运行同一版本不会重复写入），跑一遍 typecheck / build / test 校验，然后创建 `release/vX.Y.Z` 分支并打开标题为 **`release vX.Y.Z`** 的 PR（PR 正文带相同的提交记录，CHANGELOG 随提交一起进入该 PR）。
 5. 合并该 **`release vX.Y.Z`** PR。**合并即发布**——不需要再手动运行任何工作流。
 
 ## 2. 合并后自动发生什么
@@ -23,7 +23,7 @@
 2. **构建**：`pnpm run typecheck && pnpm run build && pnpm run test`（与 CI 相同的校验命令）。
 3. **发布**：`npm publish --access public`，向 npm 发布 `dsh-advisor@X.Y.Z`（认证走 `NPM_TOKEN` secret）。
 4. **打 tag**：以 `github-actions[bot]` 身份创建并推送注解 tag `vX.Y.Z`（commit message `Release vX.Y.Z`）；若该 tag 已存在，tag 步骤会跳过。**tag 跳过只覆盖 tag**——npm 不允许重复发布同一版本（`npm error ... previously published versions`），因此重跑工作流只在 **`npm publish` 步骤本身失败**（尚未发布任何版本、也未创建 tag）时才能继续完成发布；如果发布已经成功（例如随后 tag 或 GitHub Release 步骤失败），重跑会在 `npm publish` 步骤失败，而不是照常发布。**注意「已发布但未打 tag」的缺口**：发布成功后若 tag 步骤失败，仓库中没有任何 `vX.Y.Z` tag（基于 tag 的重复版本检查也拦不住该版本），此时重跑会卡在 `npm publish`；恢复只能人工处理——用 `gh release create vX.Y.Z --generate-notes`（或 `gh release create` 手动编辑正文）为已发布版本补建 tag 与 GitHub Release，或 bump 一个新版本重新走发布流程。
-5. **创建 GitHub Release**：以 `vX.Y.Z` 为 tag 与标题创建 Release，正文为自上一个 tag 以来的提交记录（`git log --oneline --first-parent`，取最近祖先 tag 为基准）。注意：Release 正文在**合并提交**上提取，会包含 `chore(release): prepare` 提交以及合并前合入的其它提交，因此可能与 PR 正文的发布说明（在 prep 时提取）略有不同——这是设计使然。
+5. **创建 GitHub Release**：以 `vX.Y.Z` 为 tag 与标题创建 Release，正文取自 `CHANGELOG.md` 中对应版本的 `## [X.Y.Z]` 小节（该小节由 **Release prep** 写入并随发布 PR 提交），因此与 PR 正文的发布说明一致。若该小节缺失（例如在引入 `CHANGELOG.md` 之前准备的旧发布 PR），则回退为自上一个 tag 以来的提交记录（`git log --oneline --first-parent`，取最近祖先 tag 为基准；无 tag 时为完整历史）。
 
 ## 3. 版本策略
 

--- a/scripts/prepare-release.mjs
+++ b/scripts/prepare-release.mjs
@@ -113,6 +113,13 @@ function updateChangelog(version) {
   } catch {
     content = CHANGELOG_HEADER
   }
+  // A 0-byte CHANGELOG.md (e.g. manual truncation) is treated as missing:
+  // an empty file must still bootstrap with the standard header, otherwise
+  // the new section would land at the top with leading blank lines and no
+  // `# Changelog` header.
+  if (content === '') {
+    content = CHANGELOG_HEADER
+  }
 
   if (content.includes(`## [${version}]`)) {
     return

--- a/scripts/prepare-release.mjs
+++ b/scripts/prepare-release.mjs
@@ -1,17 +1,21 @@
 #!/usr/bin/env node
 /**
- * Release-prep version helper (plan dsh-advisor-ci-release, task 2):
+ * Release-prep version helper (plan dsh-advisor-ci-release, task 2 + 4):
  * resolves the target version — explicit `X.Y.Z` argument or an auto patch
  * bump from package.json — refuses already-released versions (existing
- * `vX.Y.Z` git tag), bumps package.json, and prints `VERSION=<x.y.z>` for the
- * workflow to capture. Node built-ins only, no new dependencies.
+ * `vX.Y.Z` git tag), bumps package.json, inserts the `## [<version>]` section
+ * into CHANGELOG.md (from the same git-log notes the workflows use; keeps
+ * existing sections, no-op when already present), and prints
+ * `VERSION=<x.y.z>` for the workflow to capture. Node built-ins only, no new
+ * dependencies.
  *
  * Usage:
  *   node scripts/prepare-release.mjs            # auto patch bump
  *   node scripts/prepare-release.mjs 0.2.0      # explicit version
  *
  * Exit codes: 0 = bumped and printed VERSION; 1 = rejected (unparseable
- * version, existing tag, or unparseable current package.json version).
+ * version, existing tag, unparseable current package.json version, or
+ * CHANGELOG.md write error).
  */
 
 import { execFileSync } from 'node:child_process'
@@ -21,6 +25,9 @@ import { fileURLToPath } from 'node:url'
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
 const PKG_PATH = join(REPO_ROOT, 'package.json')
+const CHANGELOG_PATH = join(REPO_ROOT, 'CHANGELOG.md')
+const CHANGELOG_HEADER =
+  '# Changelog\n\nAll notable changes to dsh-advisor are documented here. Generated from git log by the release-prep workflow.\n'
 
 /** Parse strict X.Y.Z (numeric parts only); null when not parseable. */
 function parseVersion(value) {
@@ -64,5 +71,83 @@ pkg.version = version
 // line must be the only diff (verified by `git diff package.json` in the
 // dry-run validation).
 writeFileSync(PKG_PATH, `${JSON.stringify(pkg, null, 2)}\n`, 'utf8')
+
+/**
+ * Release notes since the previous release: first-parent commit subjects
+ * between the nearest ancestor tag of HEAD and HEAD. Same snippet the
+ * workflows use for the PR body — the CHANGELOG section and the PR body
+ * stay consistent. When no ancestor tag exists yet, the notes span the full
+ * first-parent history. Do NOT use "v$VERSION^": the version string is not a
+ * git ref — the bump commit is not tagged yet.
+ */
+function collectReleaseNotes() {
+  let prevTag = ''
+  try {
+    prevTag = execFileSync('git', ['describe', '--tags', '--abbrev=0', 'HEAD'], {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim()
+  } catch {
+    // No ancestor tag yet → full history.
+  }
+  const range = prevTag === '' ? 'HEAD' : `${prevTag}..HEAD`
+  return execFileSync('git', ['log', '--oneline', '--first-parent', range], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  }).trim()
+}
+
+/**
+ * Insert a `## [<version>] - <YYYY-MM-DD>` section under the `# Changelog`
+ * header, above the existing sections, from the same git-log notes the
+ * workflows use. Preserves all existing sections; no-op when the section for
+ * this version already exists (idempotent re-runs must not duplicate it);
+ * write failures exit 1.
+ */
+function updateChangelog(version) {
+  let content
+  try {
+    content = readFileSync(CHANGELOG_PATH, 'utf8')
+  } catch {
+    content = CHANGELOG_HEADER
+  }
+
+  if (content.includes(`## [${version}]`)) {
+    return
+  }
+
+  const notes = collectReleaseNotes()
+  const sectionHeader = `## [${version}] - ${new Date().toISOString().slice(0, 10)}`
+  const sectionBody =
+    notes === ''
+      ? 'No commits between releases.'
+      : notes
+          .split('\n')
+          .map((line) => `- ${line}`)
+          .join('\n')
+  const section = `${sectionHeader}\n\n${sectionBody}\n`
+
+  const lines = content.split('\n')
+  const firstSection = lines.findIndex((line) => line.startsWith('## ['))
+  let next
+  if (firstSection === -1) {
+    // No sections yet — append the new section after the header block.
+    next = `${content.trimEnd()}\n\n${section}`
+  } else {
+    lines.splice(firstSection, 0, section)
+    next = lines.join('\n')
+  }
+
+  try {
+    writeFileSync(CHANGELOG_PATH, next, 'utf8')
+  } catch (error) {
+    console.error(`Error: cannot write ${CHANGELOG_PATH}: ${error.message}`)
+    process.exit(1)
+  }
+}
+
+updateChangelog(version)
 
 console.log(`VERSION=${version}`)

--- a/scripts/prepare-release.mjs
+++ b/scripts/prepare-release.mjs
@@ -127,17 +127,24 @@ function updateChangelog(version) {
           .split('\n')
           .map((line) => `- ${line}`)
           .join('\n')
+  // The section's own trailing `\n` plus the inserted `\n` below form the
+  // blank-line separator between the new section and the existing sections.
   const section = `${sectionHeader}\n\n${sectionBody}\n`
 
-  const lines = content.split('\n')
-  const firstSection = lines.findIndex((line) => line.startsWith('## ['))
+  // Insert on the first `## [` section header via string slice: everything
+  // at and below the insertion point — including the file's exact trailing
+  // newline — is preserved byte-for-byte. (A split('\n')/splice/join('\n')
+  // round-trip would re-normalize line breaks and could alter the tail, e.g.
+  // appending a trailing newline that was not in the source file.)
+  const firstSectionMatch = /^## \[/m.exec(content)
+  const firstSectionIdx = firstSectionMatch === null ? -1 : firstSectionMatch.index
   let next
-  if (firstSection === -1) {
-    // No sections yet — append the new section after the header block.
-    next = `${content.trimEnd()}\n\n${section}`
+  if (firstSectionIdx === -1) {
+    // No sections yet — append the new section after the header block,
+    // keeping the file's own trailing-newline state.
+    next = content.endsWith('\n') ? `${content}\n${section}` : `${content}\n\n${section}`
   } else {
-    lines.splice(firstSection, 0, section)
-    next = lines.join('\n')
+    next = `${content.slice(0, firstSectionIdx)}${section}\n${content.slice(firstSectionIdx)}`
   }
 
   try {

--- a/tests/prepare-release.test.ts
+++ b/tests/prepare-release.test.ts
@@ -151,20 +151,17 @@ describe('scripts/prepare-release.mjs', () => {
       '9d293c0 Merge pull request #16 from dsh-external/chore/release-0.1.0\naf86f22 Merge pull request #15 from dsh-external/chore/deps-bump-rc3\n',
       'utf8',
     )
-    writeFileSync(
-      join(fixture, 'CHANGELOG.md'),
-      [
-        '# Changelog',
-        '',
-        'All notable changes to dsh-advisor are documented here. Generated from git log by the release-prep workflow.',
-        '',
-        '## [0.1.0] - 2026-08-13',
-        '',
-        '- 9d293c0 Merge pull request #16 from dsh-external/chore/release-0.1.0',
-        '',
-      ].join('\n'),
-      'utf8',
-    )
+    const originalChangelog = [
+      '# Changelog',
+      '',
+      'All notable changes to dsh-advisor are documented here. Generated from git log by the release-prep workflow.',
+      '',
+      '## [0.1.0] - 2026-08-13',
+      '',
+      '- 9d293c0 Merge pull request #16 from dsh-external/chore/release-0.1.0',
+      '',
+    ].join('\n')
+    writeFileSync(join(fixture, 'CHANGELOG.md'), originalChangelog, 'utf8')
     const { status, stdout } = runScript([], [])
     expect(status).toBe(0)
     expect(stdout.trim()).toBe('VERSION=0.1.1')
@@ -176,8 +173,37 @@ describe('scripts/prepare-release.mjs', () => {
     expect(changelog).toContain(
       '- 9d293c0 Merge pull request #16 from dsh-external/chore/release-0.1.0\n- af86f22 Merge pull request #15 from dsh-external/chore/deps-bump-rc3',
     )
-    // Pre-existing section survives byte-for-byte.
-    expect(changelog).toContain('## [0.1.0] - 2026-08-13\n\n- 9d293c0 Merge pull request #16 from dsh-external/chore/release-0.1.0')
+    // The pre-existing section survives byte-for-byte (F-003): everything at
+    // and below the `## [0.1.0]` header of the pre-run file is present
+    // verbatim, and the post-insert tail equals the pre-run tail exactly —
+    // same byte offset into the file, including the trailing newline.
+    const originalSectionText = originalChangelog.slice(originalChangelog.indexOf('## [0.1.0]'))
+    expect(changelog).toContain(originalSectionText)
+    expect(changelog.slice(changelog.indexOf('## [0.1.0]'))).toBe(originalSectionText)
+  })
+
+  it('CHANGELOG.md: byte-for-byte tail preservation when the file has no trailing newline', () => {
+    makeFixture('0.1.0')
+    writeFileSync(join(fixture, 'log-lines.txt'), 'abc1234 some commit\n', 'utf8')
+    // The pre-run file deliberately has NO trailing newline — the pre-fix
+    // split('\n')/splice/join('\n') path would append one after insertion
+    // and change the tail bytes.
+    const original = [
+      '# Changelog',
+      '',
+      'All notable changes to dsh-advisor are documented here. Generated from git log by the release-prep workflow.',
+      '',
+      '## [0.1.0] - 2026-08-13',
+      '',
+      '- 9d293c0 Merge pull request #16 from dsh-external/chore/release-0.1.0',
+    ].join('\n')
+    writeFileSync(join(fixture, 'CHANGELOG.md'), original, 'utf8')
+    const { status } = runScript(['0.1.1'], [])
+    expect(status).toBe(0)
+    const changelog = readFileSync(join(fixture, 'CHANGELOG.md'), 'utf8')
+    const originalSectionText = original.slice(original.indexOf('## [0.1.0]'))
+    expect(changelog).toContain(originalSectionText)
+    expect(changelog.slice(changelog.indexOf('## [0.1.0]'))).toBe(originalSectionText)
   })
 
   it('CHANGELOG.md: re-run for the same version is a no-op — the section is not duplicated', () => {

--- a/tests/prepare-release.test.ts
+++ b/tests/prepare-release.test.ts
@@ -216,4 +216,106 @@ describe('scripts/prepare-release.mjs', () => {
     const changelog = readFileSync(join(fixture, 'CHANGELOG.md'), 'utf8')
     expect(changelog.match(/^## \[0\.1\.1\] - /gm)).toHaveLength(1)
   })
+
+  it('CHANGELOG.md: missing file is created with the standard header and the new section', () => {
+    makeFixture('0.1.0')
+    writeFileSync(join(fixture, 'log-lines.txt'), 'abc1234 some commit\n', 'utf8')
+    // No CHANGELOG.md in the fixture — the script must bootstrap the file
+    // with the standard header, then insert the section under it (no leading
+    // blank lines, header first).
+    const { status, stdout } = runScript(['0.1.1'], [])
+    expect(status).toBe(0)
+    expect(stdout.trim()).toBe('VERSION=0.1.1')
+    const changelog = readFileSync(join(fixture, 'CHANGELOG.md'), 'utf8')
+    expect(changelog.startsWith('# Changelog\n')).toBe(true)
+    expect(changelog).toContain(
+      'All notable changes to dsh-advisor are documented here. Generated from git log by the release-prep workflow.',
+    )
+    expect(changelog).toMatch(/^# Changelog\n\nAll notable changes[^\n]*\n\n## \[0\.1\.1\] - \d{4}-\d{2}-\d{2}\n\n- abc1234 some commit\n$/)
+  })
+
+  it('CHANGELOG.md: header-only file (trailing newline) gets the section appended after exactly one blank line', () => {
+    makeFixture('0.1.0')
+    writeFileSync(join(fixture, 'log-lines.txt'), 'abc1234 some commit\n', 'utf8')
+    const headerOnly = [
+      '# Changelog',
+      '',
+      'All notable changes to dsh-advisor are documented here. Generated from git log by the release-prep workflow.',
+      '',
+    ].join('\n')
+    writeFileSync(join(fixture, 'CHANGELOG.md'), headerOnly, 'utf8')
+    const { status } = runScript(['0.1.1'], [])
+    expect(status).toBe(0)
+    const changelog = readFileSync(join(fixture, 'CHANGELOG.md'), 'utf8')
+    // One blank line separates the header block from the new section; the
+    // section is the last content and the file keeps its trailing newline.
+    expect(changelog).toMatch(/^# Changelog\n\nAll notable changes[^\n]*\n\n## \[0\.1\.1\] - \d{4}-\d{2}-\d{2}\n\n- abc1234 some commit\n$/)
+  })
+
+  it('CHANGELOG.md: header-only file (no trailing newline) gets the section appended with a blank-line separator', () => {
+    makeFixture('0.1.0')
+    writeFileSync(join(fixture, 'log-lines.txt'), 'abc1234 some commit\n', 'utf8')
+    const headerOnly = [
+      '# Changelog',
+      '',
+      'All notable changes to dsh-advisor are documented here. Generated from git log by the release-prep workflow.',
+    ].join('\n')
+    writeFileSync(join(fixture, 'CHANGELOG.md'), headerOnly, 'utf8')
+    const { status } = runScript(['0.1.1'], [])
+    expect(status).toBe(0)
+    const changelog = readFileSync(join(fixture, 'CHANGELOG.md'), 'utf8')
+    expect(changelog).toMatch(/^# Changelog\n\nAll notable changes[^\n]*\n\n## \[0\.1\.1\] - \d{4}-\d{2}-\d{2}\n\n- abc1234 some commit\n$/)
+  })
+
+  it('CHANGELOG.md: 0-byte file is bootstrapped like a missing file (header + section, no leading blank lines)', () => {
+    makeFixture('0.1.0')
+    writeFileSync(join(fixture, 'log-lines.txt'), 'abc1234 some commit\n', 'utf8')
+    // An existing-but-empty CHANGELOG.md must take the missing-file path:
+    // pre-fix, the append branch produced a headerless file that starts with
+    // blank lines instead of `# Changelog`.
+    writeFileSync(join(fixture, 'CHANGELOG.md'), '', 'utf8')
+    const { status } = runScript(['0.1.1'], [])
+    expect(status).toBe(0)
+    const changelog = readFileSync(join(fixture, 'CHANGELOG.md'), 'utf8')
+    expect(changelog.startsWith('# Changelog\n')).toBe(true)
+    expect(changelog).toMatch(/^# Changelog\n\nAll notable changes[^\n]*\n\n## \[0\.1\.1\] - \d{4}-\d{2}-\d{2}\n\n- abc1234 some commit\n$/)
+  })
+
+  it('CHANGELOG.md: nearest ancestor tag — notes use the <tag>..HEAD range and the section lists only post-tag commits', () => {
+    makeFixture('0.1.0')
+    // The fake git shim echoes `git describe` from describe-tag.txt and
+    // asserts `git log` receives the `v0.1.0..HEAD` range (exit 2 otherwise),
+    // so a regression to e.g. `v$VERSION^` fails the run.
+    writeFileSync(join(fixture, 'describe-tag.txt'), 'v0.1.0\n', 'utf8')
+    writeFileSync(
+      join(fixture, 'log-lines.txt'),
+      'b0b1c2d post-tag commit 2\na1a2b3c post-tag commit 1\n',
+      'utf8',
+    )
+    // Realistic pre-existing file: the released 0.1.0 section is already
+    // committed; preparing 0.1.1 lists only commits after the v0.1.0 tag.
+    const original = [
+      '# Changelog',
+      '',
+      'All notable changes to dsh-advisor are documented here. Generated from git log by the release-prep workflow.',
+      '',
+      '## [0.1.0] - 2026-08-13',
+      '',
+      '- 9d293c0 Merge pull request #16 from dsh-external/chore/release-0.1.0',
+      '',
+    ].join('\n')
+    writeFileSync(join(fixture, 'CHANGELOG.md'), original, 'utf8')
+    const { status, stdout } = runScript(['0.1.1'], [])
+    expect(status).toBe(0)
+    expect(stdout.trim()).toBe('VERSION=0.1.1')
+    const changelog = readFileSync(join(fixture, 'CHANGELOG.md'), 'utf8')
+    const newSection = changelog.slice(changelog.indexOf('## [0.1.1]'), changelog.indexOf('## [0.1.0]'))
+    // Only post-tag commits (the v0.1.0..HEAD range) are listed as bullets,
+    // in git-log order (newest first: log-lines.txt line 1 → first bullet).
+    expect(newSection).toContain('- b0b1c2d post-tag commit 2\n- a1a2b3c post-tag commit 1')
+    expect(newSection).not.toContain('9d293c0')
+    // The pre-existing 0.1.0 section survives byte-for-byte below.
+    const originalSectionText = original.slice(original.indexOf('## [0.1.0]'))
+    expect(changelog.slice(changelog.indexOf('## [0.1.0]'))).toBe(originalSectionText)
+  })
 })

--- a/tests/prepare-release.test.ts
+++ b/tests/prepare-release.test.ts
@@ -1,11 +1,14 @@
 /**
  * CI coverage for scripts/prepare-release.mjs (plan dsh-advisor-ci-release,
- * QC1 F-004). The script resolves REPO_ROOT from its own file location
- * (import.meta.url), NOT cwd, so each case runs a COPY of the script inside
- * a temp fixture: the fixture's package.json is the file the script reads
- * and bumps, and a fake `git` shim on PATH stands in for `git rev-parse` so
- * tag existence is controlled without a real git repo or any network.
- * Deterministic and fast: real node subprocesses, no installs.
+ * QC1 F-004, task 4 CHANGELOG). The script resolves REPO_ROOT from its own
+ * file location (import.meta.url), NOT cwd, so each case runs a COPY of the
+ * script inside a temp fixture: the fixture's package.json is the file the
+ * script reads and bumps, its CHANGELOG.md is what the script updates, and a
+ * fake `git` shim on PATH stands in for `git rev-parse` (tag existence),
+ * `git describe` (nearest ancestor tag) and `git log` (commit subjects) so
+ * tag resolution and release-note collection are controlled without a real
+ * git repo or any network. Deterministic and fast: real node subprocesses,
+ * no installs.
  *
  * Note: the script wraps its tag check in try/catch and calls process.exit
  * inside it, so in-process exit stubbing would be swallowed; spawning the
@@ -23,9 +26,16 @@ const repo = resolve(here, '..')
 const scriptPath = resolve(repo, 'scripts', 'prepare-release.mjs')
 
 /**
- * Minimal git stand-in: only `git rev-parse <tag>` is ever invoked. Tags
- * listed in ../existing-tags.txt "exist" (exit 0, prints a sha); all other
- * tags fail like an unknown revision (exit 128).
+ * Minimal git stand-in. Only three invocations are ever made:
+ *  - `git rev-parse <tag>`      — tags listed in ../existing-tags.txt
+ *    "exist" (exit 0, prints a sha); all other tags fail like an unknown
+ *    revision (exit 128).
+ *  - `git describe --tags --abbrev=0 HEAD` — echoes ../describe-tag.txt when
+ *    non-empty (nearest ancestor tag); otherwise fails like "no tags" (exit
+ *    128), so the script falls back to the full first-parent history.
+ *  - `git log --oneline --first-parent <range>` — asserts the range is
+ *    `<describe-tag>..HEAD` when a describe tag is set, else `HEAD`, then
+ *    echoes ../log-lines.txt (the fixture's commit subjects).
  */
 const GIT_SHIM = `#!/bin/sh
 if [ "$1" = "rev-parse" ]; then
@@ -36,6 +46,29 @@ if [ "$1" = "rev-parse" ]; then
   fi
   echo "fatal: ambiguous argument '$tag': unknown revision or path not in the working tree." >&2
   exit 128
+fi
+if [ "$1" = "describe" ]; then
+  desc_file="$(dirname "$0")/../describe-tag.txt"
+  if [ -s "$desc_file" ]; then
+    cat "$desc_file"
+    exit 0
+  fi
+  echo "fatal: No names found, cannot describe anything." >&2
+  exit 128
+fi
+if [ "$1" = "log" ]; then
+  range="$4"
+  desc_file="$(dirname "$0")/../describe-tag.txt"
+  expected="HEAD"
+  if [ -s "$desc_file" ]; then
+    expected="$(cat "$desc_file")..HEAD"
+  fi
+  if [ "$range" != "$expected" ]; then
+    echo "prepare-release.test: unexpected git log range '$range' (expected '$expected')" >&2
+    exit 2
+  fi
+  cat "$(dirname "$0")/../log-lines.txt" 2>/dev/null
+  exit 0
 fi
 echo "prepare-release.test: unexpected git invocation: $*" >&2
 exit 2
@@ -107,5 +140,54 @@ describe('scripts/prepare-release.mjs', () => {
     expect(status).toBe(1)
     expect(stderr).toContain('already exists')
     expect(fixtureVersion()).toBe('0.1.0')
+  })
+
+  it('writes CHANGELOG.md: inserts ## [<version>] section under the header and preserves prior sections', () => {
+    makeFixture('0.1.0')
+    // No ancestor tag (describe-tag.txt absent) → notes span the full main
+    // line; the fixture supplies the first-parent commit subjects.
+    writeFileSync(
+      join(fixture, 'log-lines.txt'),
+      '9d293c0 Merge pull request #16 from dsh-external/chore/release-0.1.0\naf86f22 Merge pull request #15 from dsh-external/chore/deps-bump-rc3\n',
+      'utf8',
+    )
+    writeFileSync(
+      join(fixture, 'CHANGELOG.md'),
+      [
+        '# Changelog',
+        '',
+        'All notable changes to dsh-advisor are documented here. Generated from git log by the release-prep workflow.',
+        '',
+        '## [0.1.0] - 2026-08-13',
+        '',
+        '- 9d293c0 Merge pull request #16 from dsh-external/chore/release-0.1.0',
+        '',
+      ].join('\n'),
+      'utf8',
+    )
+    const { status, stdout } = runScript([], [])
+    expect(status).toBe(0)
+    expect(stdout.trim()).toBe('VERSION=0.1.1')
+    const changelog = readFileSync(join(fixture, 'CHANGELOG.md'), 'utf8')
+    // New section is present, sits above the pre-existing section, and
+    // carries the git-log notes as bullet items.
+    expect(changelog).toContain('## [0.1.1] - ')
+    expect(changelog.indexOf('## [0.1.1]')).toBeLessThan(changelog.indexOf('## [0.1.0]'))
+    expect(changelog).toContain(
+      '- 9d293c0 Merge pull request #16 from dsh-external/chore/release-0.1.0\n- af86f22 Merge pull request #15 from dsh-external/chore/deps-bump-rc3',
+    )
+    // Pre-existing section survives byte-for-byte.
+    expect(changelog).toContain('## [0.1.0] - 2026-08-13\n\n- 9d293c0 Merge pull request #16 from dsh-external/chore/release-0.1.0')
+  })
+
+  it('CHANGELOG.md: re-run for the same version is a no-op — the section is not duplicated', () => {
+    makeFixture('0.1.0')
+    writeFileSync(join(fixture, 'log-lines.txt'), 'abc1234 some commit\n', 'utf8')
+    const first = runScript(['0.1.1'], [])
+    expect(first.status).toBe(0)
+    const second = runScript(['0.1.1'], [])
+    expect(second.status).toBe(0)
+    const changelog = readFileSync(join(fixture, 'CHANGELOG.md'), 'utf8')
+    expect(changelog.match(/^## \[0\.1\.1\] - /gm)).toHaveLength(1)
   })
 })


### PR DESCRIPTION
## What

Task 4 of the CI/release plan (user decision): release PRs now carry a CHANGELOG change.

- **CHANGELOG.md**: new file, honest `## [0.1.0]` section from real history
- **prepare-release.mjs**: inserts `## [<version>] - <date>` section from git log (nearest-ancestor-tag range, `--first-parent`), byte-preserving, idempotent, empty-file bootstrap
- **release-prep.yml**: PR body = CHANGELOG section + merge-instruction line (same extraction as Release)
- **release.yml**: Release body = CHANGELOG section (guarded awk + git-log fallback); strict X.Y.Z validate before publish
- **docs/release.md**: runbook updated (CHANGELOG auto-gen; in-flight pre-CHANGELOG PR fallback note)
- **tests**: 5 new cases (bootstrap paths ×4, describe-success ×1) — 311 total

## Checks

- 311 tests pass, typecheck clean, actionlint clean ×2
- awk blocks byte-identical across both workflows; prefix-safe version match (0.1.1 ≠ 0.1.10, ≠ 0x1y1)
- PR body / Release body same extraction source (PR adds merge instruction only)
- SDD: task review + fix waves + plan QC tri ×3 Approve + targeted re-review ×2 Approve, zero-residual

Plan: .mstar/plans/dsh-advisor-ci-release.md (Task 4, gitignored)