### PR TITLE
fix: switch publish to OIDC trusted publishing, support prerelease versions

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -1,16 +1,18 @@
 name: Release prep
 
 # Manual entry point: Actions → "Release prep" → Run workflow (optionally pass
-# an explicit X.Y.Z). Bumps package.json (+ lockfile sync), validates the
-# build, and opens a `release vX.Y.Z` PR. Merging that PR runs the Release
-# workflow, which publishes dsh-advisor@X.Y.Z, pushes tag vX.Y.Z, and creates
-# the GitHub Release.
+# an explicit X.Y.Z or X.Y.Z-prerelease, e.g. 0.1.1-alpha.1). Bumps
+# package.json (+ lockfile sync), validates the build, and opens a
+# `release v<version>` PR. Merging that PR runs the Release workflow, which
+# publishes dsh-advisor@<version> (formal versions to `latest`, prereleases to
+# their prerelease dist-tag), pushes tag v<version>, and creates the GitHub
+# Release.
 
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Target version (e.g. 0.2.0). Leave empty for auto patch bump."
+        description: "Target version (e.g. 0.2.0, or 0.1.1-alpha.1 for a prerelease). Leave empty for auto patch bump."
         required: false
         type: string
 
@@ -56,9 +58,11 @@ jobs:
           if [ -z "$V" ]; then V="auto"; fi
           # First-line guard: validate an explicit input before it is echoed
           # into GITHUB_OUTPUT or passed to git rev-parse. prepare-release.mjs
-          # still validates downstream; this is defense in depth.
-          if [ "$V" != "auto" ] && ! [[ "$V" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::Invalid version input \"$V\". Expected X.Y.Z (e.g. 0.2.0)."
+          # still validates downstream; this is defense in depth. Accepts
+          # X.Y.Z or X.Y.Z-prerelease (semver; prerelease chars
+          # [0-9A-Za-z.-]+), e.g. 0.2.0, 0.1.1-alpha.1.
+          if [ "$V" != "auto" ] && ! [[ "$V" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Invalid version input \"$V\". Expected X.Y.Z or X.Y.Z-prerelease (e.g. 0.2.0, 0.1.1-alpha.1)."
             exit 1
           fi
           if [ "$V" != "auto" ] && git rev-parse "v$V" >/dev/null 2>&1; then
@@ -110,8 +114,10 @@ jobs:
             # Escape regex metacharacters in the version inside awk (the gsub
             # runs after `-v` argument escape processing, which would strip
             # backslashes from a shell-escaped value) so the anchor matches
-            # literally: dots must not act as any-char. VERSION is strict
-            # X.Y.Z upstream, so only dots are ever present.
+            # literally: dots must not act as any-char. VERSION is validated
+            # upstream (X.Y.Z or X.Y.Z-prerelease); '-' is a literal character
+            # in awk ERE outside a character class, so prerelease suffixes
+            # need no extra escaping.
             awk -v v="$VERSION" '
               BEGIN { gsub(/\./, "\\\\&", v) }
               /^## \[/ { if (in_section) exit }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,11 +3,16 @@ name: Release
 # PR-driven release. Merging a `release vX.Y.Z` PR (opened by the Release prep
 # workflow) runs the whole release inline on the pull_request event:
 # validate -> sanity gate -> npm publish dsh-advisor@X.Y.Z -> create+push the
-# vX.Y.Z tag (skipped if it already exists) -> GitHub Release.
+# vX.Y.Z tag (skipped if it already exists) -> GitHub Release. Prerelease
+# versions (e.g. v0.1.1-alpha.1) are supported: they publish to a prerelease
+# npm dist-tag and never touch the `latest` tag.
 #
-# The workflow runs on the merged release PR event, so no secrets are required
-# for the default flow except NPM_TOKEN (npm registry auth for publish). The
-# tag and GitHub Release are created with the workflow's GITHUB_TOKEN.
+# npm publish uses OIDC trusted publishing (`permissions: id-token: write`
+# below): no NODE_AUTH_TOKEN / NPM_TOKEN secret is required — npm exchanges
+# the workflow's OIDC token for a short-lived publish token. The npmjs org
+# must configure a trusted publisher for this repository + workflow (see
+# https://docs.npmjs.com/generating-provenance-statements). The tag and
+# GitHub Release are created with the workflow's GITHUB_TOKEN.
 #
 # NOTE: publish happens BEFORE tag creation (mirror mstar-harness). If the tag
 # already exists (e.g. a re-run after a partial failure), publish still
@@ -20,6 +25,9 @@ on:
 
 permissions:
   contents: write
+  # id-token: write enables OIDC token exchange for npm trusted publishing
+  # (publish step below); the GitHub Release + tag steps use GITHUB_TOKEN.
+  id-token: write
 
 concurrency:
   group: release
@@ -68,12 +76,15 @@ jobs:
             echo "::error::package.json version is empty; refusing to release."
             exit 1
           fi
-          # Strict X.Y.Z guard (mirror release-prep): the version flows into
+          # Version guard (mirror release-prep): X.Y.Z or X.Y.Z-prerelease
+          # (semver; prerelease chars [0-9A-Za-z.-]+). The version flows into
           # an awk regex anchor below; reject metacharacters up front so a
           # malformed package.json version cannot break the extraction (awk
-          # exit-2) after publish.
-          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::Invalid version \"$VERSION\" in package.json. Expected X.Y.Z."
+          # exit-2) after publish. '-' is a literal character in awk ERE
+          # outside a character class, so prerelease suffixes need no extra
+          # escaping there.
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Invalid version \"$VERSION\" in package.json. Expected X.Y.Z or X.Y.Z-prerelease (e.g. 0.2.0, 0.1.1-alpha.1)."
             exit 1
           fi
           # Tag-exists policy (mirror mstar-harness): publish proceeds even if
@@ -87,8 +98,6 @@ jobs:
           pnpm run build
           pnpm run test
 
-      # npm auth: setup-node wrote `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}`
-      # into .npmrc; this step supplies the token from the NPM_TOKEN secret.
       - name: Assert packed tarball contents (pre-publish guard)
         run: |
           set -euo pipefail
@@ -102,8 +111,27 @@ jobs:
 
       - name: Publish to npm
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access public
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          set -euo pipefail
+          # OIDC trusted publishing: no NODE_AUTH_TOKEN / NPM_TOKEN env or
+          # secret — npm exchanges the workflow's id-token (permissions above)
+          # for a short-lived publish token with provenance. The npmjs org must
+          # have a trusted publisher configured for this repo + workflow.
+          #
+          # Prerelease dist-tag: a version containing '-' (e.g.
+          # 0.1.1-alpha.1) publishes to the prerelease-prefix tag (text
+          # between the first '-' and the first '.' after it -> "alpha")
+          # instead of the default `latest`, so prereleases never clobber the
+          # latest release and consumers opting into the tag can install it.
+          # Formal X.Y.Z versions publish without --tag (default latest).
+          if [[ "${VERSION}" == *-* ]]; then
+            PRETAG="${VERSION#*-}"
+            PRETAG="${PRETAG%%.*}"
+            npm publish --access public --tag "$PRETAG"
+          else
+            npm publish --access public
+          fi
 
       - name: Configure git identity
         run: |
@@ -128,8 +156,10 @@ jobs:
             # Escape regex metacharacters in the version inside awk (the gsub
             # runs after `-v` argument escape processing, which would strip
             # backslashes from a shell-escaped value) so the anchor matches
-            # literally: dots must not act as any-char. VERSION is strict
-            # X.Y.Z upstream, so only dots are ever present.
+            # literally: dots must not act as any-char. VERSION is validated
+            # upstream (X.Y.Z or X.Y.Z-prerelease); '-' is a literal character
+            # in awk ERE outside a character class, so prerelease suffixes
+            # need no extra escaping.
             awk -v v="$VERSION" '
               BEGIN { gsub(/\./, "\\\\&", v) }
               /^## \[/ { if (in_section) exit }

--- a/scripts/prepare-release.mjs
+++ b/scripts/prepare-release.mjs
@@ -1,17 +1,18 @@
 #!/usr/bin/env node
 /**
  * Release-prep version helper (plan dsh-advisor-ci-release, task 2 + 4):
- * resolves the target version — explicit `X.Y.Z` argument or an auto patch
- * bump from package.json — refuses already-released versions (existing
- * `vX.Y.Z` git tag), bumps package.json, inserts the `## [<version>]` section
- * into CHANGELOG.md (from the same git-log notes the workflows use; keeps
- * existing sections, no-op when already present), and prints
- * `VERSION=<x.y.z>` for the workflow to capture. Node built-ins only, no new
- * dependencies.
+ * resolves the target version — explicit `X.Y.Z` / `X.Y.Z-prerelease`
+ * argument (e.g. 0.1.1-alpha.1) or an auto patch bump from package.json —
+ * refuses already-released versions (existing `v<version>` git tag), bumps
+ * package.json, inserts the `## [<version>]` section into CHANGELOG.md (from
+ * the same git-log notes the workflows use; keeps existing sections, no-op
+ * when already present), and prints `VERSION=<version>` for the workflow to
+ * capture. Node built-ins only, no new dependencies.
  *
  * Usage:
  *   node scripts/prepare-release.mjs            # auto patch bump
  *   node scripts/prepare-release.mjs 0.2.0      # explicit version
+ *   node scripts/prepare-release.mjs 0.1.1-alpha.1  # explicit prerelease
  *
  * Exit codes: 0 = bumped and printed VERSION; 1 = rejected (unparseable
  * version, existing tag, unparseable current package.json version, or
@@ -29,11 +30,25 @@ const CHANGELOG_PATH = join(REPO_ROOT, 'CHANGELOG.md')
 const CHANGELOG_HEADER =
   '# Changelog\n\nAll notable changes to dsh-advisor are documented here. Generated from git log by the release-prep workflow.\n'
 
-/** Parse strict X.Y.Z (numeric parts only); null when not parseable. */
+/**
+ * Parse X.Y.Z or X.Y.Z[-prerelease] (numeric parts; optional prerelease
+ * suffix); null when not parseable. The suffix character set matches the
+ * workflows' guard regex `[0-9A-Za-z.-]+` (keep-simple: no leading-zero or
+ * empty-identifier rules), with one tightening: the suffix MUST contain at
+ * least one digit, so `0.1.1-alpha.1` / `0.1.1-rc.2` parse but `0.1.1-alpha`
+ * (no numeric identifier) and `0.1.1-` (empty suffix) are rejected. Returns
+ * { major, minor, patch, prerelease? } — prerelease is the raw suffix text
+ * (e.g. 'alpha.1') when present, undefined for formal versions.
+ */
 function parseVersion(value) {
-  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(value)
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]*[0-9][0-9A-Za-z.-]*))?$/.exec(value)
   if (!match) return null
-  return { major: Number(match[1]), minor: Number(match[2]), patch: Number(match[3]) }
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    prerelease: match[4] === undefined ? undefined : match[4],
+  }
 }
 
 const pkg = JSON.parse(readFileSync(PKG_PATH, 'utf8'))
@@ -42,7 +57,7 @@ let target
 if (process.argv[2] !== undefined) {
   target = parseVersion(process.argv[2])
   if (target === null) {
-    console.error(`Error: invalid version "${process.argv[2]}". Expected X.Y.Z (e.g. 0.2.0).`)
+    console.error(`Error: invalid version "${process.argv[2]}". Expected X.Y.Z or X.Y.Z-prerelease (e.g. 0.2.0, 0.1.1-alpha.1).`)
     process.exit(1)
   }
 } else {
@@ -51,13 +66,21 @@ if (process.argv[2] !== undefined) {
     console.error(`Error: cannot parse current package.json version "${pkg.version}".`)
     process.exit(1)
   }
+  // Auto patch bump: bump the numeric patch part and DROP any prerelease
+  // suffix (a prerelease base 0.1.1-alpha.1 with no explicit arg -> 0.1.2,
+  // i.e. the next formal patch after the 0.1.1 line). An explicit prerelease
+  // argument is the way to prepare another prerelease (e.g. 0.1.1-alpha.2).
   target = { major: current.major, minor: current.minor, patch: current.patch + 1 }
 }
 
-const version = `${target.major}.${target.minor}.${target.patch}`
+const version =
+  target.prerelease === undefined
+    ? `${target.major}.${target.minor}.${target.patch}`
+    : `${target.major}.${target.minor}.${target.patch}-${target.prerelease}`
 
-// Reject already-released versions: `git rev-parse vX.Y.Z` succeeds iff the
-// tag exists. Run from REPO_ROOT so the check is cwd-independent.
+// Reject already-released versions: `git rev-parse v<version>` succeeds iff
+// the tag exists. Works unchanged for prerelease tags (v0.1.1-alpha.1 is a
+// plain tag name). Run from REPO_ROOT so the check is cwd-independent.
 try {
   execFileSync('git', ['rev-parse', `v${version}`], { cwd: REPO_ROOT, stdio: 'ignore' })
   console.error(`Error: tag v${version} already exists — this version is already released.`)

--- a/tests/prepare-release.test.ts
+++ b/tests/prepare-release.test.ts
@@ -318,4 +318,54 @@ describe('scripts/prepare-release.mjs', () => {
     const originalSectionText = original.slice(original.indexOf('## [0.1.0]'))
     expect(changelog.slice(changelog.indexOf('## [0.1.0]'))).toBe(originalSectionText)
   })
+
+  it('explicit prerelease 0.1.1-alpha.1 is accepted: VERSION printed, package.json + CHANGELOG updated', () => {
+    makeFixture('0.1.1')
+    writeFileSync(join(fixture, 'log-lines.txt'), 'abc1234 some commit\n', 'utf8')
+    const original = [
+      '# Changelog',
+      '',
+      'All notable changes to dsh-advisor are documented here. Generated from git log by the release-prep workflow.',
+      '',
+      '## [0.1.0] - 2026-08-13',
+      '',
+      '- 9d293c0 Merge pull request #16 from dsh-external/chore/release-0.1.0',
+      '',
+    ].join('\n')
+    writeFileSync(join(fixture, 'CHANGELOG.md'), original, 'utf8')
+    const { status, stdout, stderr } = runScript(['0.1.1-alpha.1'], [])
+    expect(status).toBe(0)
+    expect(stdout.trim()).toBe('VERSION=0.1.1-alpha.1')
+    expect(stderr).toBe('')
+    expect(fixtureVersion()).toBe('0.1.1-alpha.1')
+    const changelog = readFileSync(join(fixture, 'CHANGELOG.md'), 'utf8')
+    // The prerelease header extracts with the same `## [<version>]` pattern
+    // the workflows awk on; it sits above the pre-existing section.
+    expect(changelog).toContain('## [0.1.1-alpha.1] - ')
+    expect(changelog.indexOf('## [0.1.1-alpha.1]')).toBeLessThan(changelog.indexOf('## [0.1.0]'))
+    expect(changelog).toContain('- abc1234 some commit')
+    const originalSectionText = original.slice(original.indexOf('## [0.1.0]'))
+    expect(changelog.slice(changelog.indexOf('## [0.1.0]'))).toBe(originalSectionText)
+  })
+
+  it('auto patch bump on a prerelease base drops the suffix: 0.1.1-alpha.1 -> 0.1.2', () => {
+    makeFixture('0.1.1-alpha.1')
+    const { status, stdout, stderr } = runScript([], [])
+    expect(status).toBe(0)
+    expect(stdout.trim()).toBe('VERSION=0.1.2')
+    expect(stderr).toBe('')
+    expect(fixtureVersion()).toBe('0.1.2')
+  })
+
+  it('invalid prerelease versions are rejected: exit 1 + stderr message, package.json untouched', () => {
+    // '0.1.1-alpha' has no numeric identifier and '0.1.1-' has an empty
+    // suffix — both rejected by the parse (suffix must contain a digit).
+    for (const bad of ['0.1.1-alpha', '0.1.1-']) {
+      makeFixture('0.1.1')
+      const { status, stderr } = runScript([bad], [])
+      expect(status).toBe(1)
+      expect(stderr).toContain('invalid version')
+      expect(fixtureVersion()).toBe('0.1.1')
+    }
+  })
 })


### PR DESCRIPTION
## What

Release publish failed (run 31812507810): `NODE_AUTH_TOKEN` resolved empty — `NPM_TOKEN` secret no longer exists (404). User decision: switch to OIDC trusted publishing (mstar-harness pattern).

## Change

- **release.yml**: `permissions: contents: write + id-token: write`; publish step drops `NODE_AUTH_TOKEN` env entirely (npm OIDC exchange, no secret)
- **Prerelease support** (next release = 0.1.1-alpha.1):
  - Version validation now `X.Y.Z[-prerelease]` in both workflows
  - prepare-release.mjs parses prerelease (auto-patch drops suffix: 0.1.1-alpha.1 → 0.1.2)
  - npm publish uses dist-tag `--tag <prefix>` for prereleases (0.1.1-alpha.1 → alpha), formal → latest
  - CHANGELOG `## [0.1.1-alpha.1]` extraction verified prefix-safe (no awk change needed)
- 3 new fixture tests (prerelease accepted / auto-patch drops suffix / invalid rejected) — 314 total

## Prerequisite (npmjs side)

Configure trusted publishing on npmjs: package dsh-advisor → trusted publisher → this repo + Release workflow. No repo secret needed.

## Checks

- 314 tests, typecheck, actionlint clean ×2
- No secrets/NPM_TOKEN reference remains in release.yml (only prose)