### PR TITLE
release v0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-advisor",
-  "version": "0.1.1-alpha.1",
+  "version": "0.1.1",
   "type": "module",
   "description": "dsh plugin bundle porting the omp advisor subsystem: a per-session reviewer model that observes the primary transcript and injects severity-ranked advice (nit/concern/blocker).",
   "repository": {


### PR DESCRIPTION
## [0.1.1] - 2026-08-14

- 3163155 Merge pull request #24 from omdsh-dev/fix/release-reopen
- a1cab77 Merge pull request #22 from omdsh-dev/feat/release-changelog
- c963f3a Merge pull request #20 from omdsh-dev/fix/release-pat
- 5771d6c Merge pull request #19 from omdsh-dev/fix/release-label
- bd5672b Merge pull request #18 from omdsh-dev/ops/ci-release
- b714ce1 Merge pull request #17 from yuezengwu/codex/rc6-schemastery-peer
- 182867b docs: switch install to registry package dsh-advisor
- 56aa668 docs: point install commands at btspoony/dsh-advisor after repo transfer
- 64497e3 chore(deps): bump all @deepseek-ai/dsh-* peers to ^0.1.0-rc.6
- e6bbfa0 chore(config): first-party release-age exemption, drop repo .npmrc, refresh lockfile
- 9d293c0 Merge pull request #16 from dsh-external/chore/release-0.1.0
- af86f22 Merge pull request #15 from dsh-external/chore/deps-bump-rc3
- 068c511 Merge pull request #14 from dsh-external/fix/gateway-typert-explicit-registration
- 4f1771a Merge pull request #13 from dsh-external/chore/registry-rc5-peers
- 90909f6 Merge pull request #12 from dsh-external/fix/dsh-rc2-rename-migration
- dd2ae3b fix(install): guard host-profile installs and pin virtual-store react identity
- 294aff1 docs(knowledge): compound pnpm 11 install lessons from PR #11
- 1b91d10 Merge pull request #11 from dsh-external/fix/windows-pnpm11-install
- 3fa42f8 fix(docs): swap screenshot contents — settings card vs injected note were reversed
- c2d93c1 docs(readme): move Settings-page screenshot to the top of the Config section
- aa763d2 docs(readme): use relative screenshot paths (private repo — raw URLs need auth)
- e436d84 docs(readme): add Advisor settings-card and injected-note screenshots (hosted on gh raw)
- 04024de Merge pull request #10 from dsh-external/iteration/iter-20260811-dsh-advisor-ux
- c6e095a Merge pull request #9 from dsh-external/iteration/iter-20260811-dsh-advisor-n6
- d292ed6 chore: update gitignore
- 6280963 refactor: migrate cordis package references to @deepseek-ai/cordis
- 4dac052 fix(compat): dsh 20260811 snapshot compatibility — advisor plugin tree load
- b0b4e20 docs(client): correct section docstring — notice covers channel unreachability, not no-settings-service (qc2 M-1)
- f3007e3 Merge pull request #8 from dsh-external/iteration/iter-20260810-dsh-advisor-n5
- 7e20c6a fix(settings): drop non-existent exposeToWebClients — upstream has no opt-in
- a1767a4 Merge pull request #7 from dsh-external/iteration/iter-20260810-dsh-advisor-patch-retirement
- 6a0a37e chore: update npmrc
- 7e11da5 chore: update npmrc
- 70c7a03 Merge pull request #6 from dsh-external/iteration/iter-20260810-dsh-advisor-n4
- 10268f6 Merge pull request #5 from dsh-external/iteration/iter-20260810-dsh-advisor-n3
- 8073b34 Merge pull request #4 from dsh-external/iteration/iter-20260810-dsh-advisor-host-fix
- 7caf7e1 docs: use deepseek-official / deepseek-v4-flash in config example
- 99a0e19 docs: streamline install section and use web profile in examples
- 804af27 docs: use static shields badges in READMEs
- b05ee44 refactor(dev): link real dsh packages via DSH_HOME instead of peer-stubs (#3)
- 10b231f Merge pull request #2 from dsh-external/iteration/iter-20260810-dsh-advisor-n2
- 3d4adfb feat: dsh advisor plugin — core single-advisor MVP (omp port) (#1)
- 2975cb6 Initial commit


Merging this PR tags v0.1.1 and publishes dsh-advisor@0.1.1 via the Release workflow.
