### PR TITLE
fix: handle previously-merged release PRs, mark prerelease releases, align version validation

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -59,9 +59,11 @@ jobs:
           # First-line guard: validate an explicit input before it is echoed
           # into GITHUB_OUTPUT or passed to git rev-parse. prepare-release.mjs
           # still validates downstream; this is defense in depth. Accepts
-          # X.Y.Z or X.Y.Z-prerelease (semver; prerelease chars
-          # [0-9A-Za-z.-]+), e.g. 0.2.0, 0.1.1-alpha.1.
-          if [ "$V" != "auto" ] && ! [[ "$V" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+          # X.Y.Z or X.Y.Z-prerelease (semver; the suffix must contain at
+          # least one digit, matching parseVersion in prepare-release.mjs),
+          # e.g. 0.2.0, 0.1.1-alpha.1; digitless suffixes like 0.1.1-alpha
+          # are rejected.
+          if [ "$V" != "auto" ] && ! [[ "$V" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]*[0-9][0-9A-Za-z.-]*)?$ ]]; then
             echo "::error::Invalid version input \"$V\". Expected X.Y.Z or X.Y.Z-prerelease (e.g. 0.2.0, 0.1.1-alpha.1)."
             exit 1
           fi
@@ -173,23 +175,36 @@ jobs:
           } > /tmp/pr-body.md
           if gh pr view "$BRANCH" >/dev/null 2>&1; then
             STATE="$(gh pr view "$BRANCH" --json state --jq .state)"
-            if [ "$STATE" = "CLOSED" ]; then
-              if gh pr reopen "$BRANCH" 2>/dev/null; then
-                echo "Reopened previously closed release PR for $BRANCH"
-              else
-                # GitHub rejects reopening a closed PR whose head branch was
-                # force-pushed (reopenPullRequest error). The release branch is
-                # force-pushed by the Commit step above, so a stale closed PR
-                # from an earlier prep run hits this. Degrade: open a fresh PR
-                # on the same branch (the old closed PR stays as history).
-                echo "::warning::cannot reopen closed release PR for $BRANCH (head force-pushed?) — opening a fresh PR"
+            case "$STATE" in
+              OPEN)
+                gh pr edit "$BRANCH" --title "$TITLE" --body-file /tmp/pr-body.md --add-label release
+                echo "Updated existing release PR for $BRANCH"
+                ;;
+              CLOSED)
+                if gh pr reopen "$BRANCH" 2>/dev/null; then
+                  echo "Reopened previously closed release PR for $BRANCH"
+                  gh pr edit "$BRANCH" --title "$TITLE" --body-file /tmp/pr-body.md --add-label release
+                  echo "Updated existing release PR for $BRANCH"
+                else
+                  # GitHub rejects reopening a closed PR whose head branch was
+                  # force-pushed (reopenPullRequest error). The release branch is
+                  # force-pushed by the Commit step above, so a stale closed PR
+                  # from an earlier prep run hits this. Degrade: open a fresh PR
+                  # on the same branch (the old closed PR stays as history).
+                  echo "::warning::cannot reopen closed release PR for $BRANCH (head force-pushed?) — opening a fresh PR"
+                  gh pr create --base main --head "$BRANCH" --title "$TITLE" \
+                    --body-file /tmp/pr-body.md --label release
+                fi
+                ;;
+              MERGED)
+                # An earlier release PR with this branch name was merged; the
+                # branch has been force-pushed with new content — open a fresh
+                # PR (old one stays closed as history).
+                echo "::warning::release PR for $BRANCH was previously merged — opening a fresh PR for the new branch state"
                 gh pr create --base main --head "$BRANCH" --title "$TITLE" \
                   --body-file /tmp/pr-body.md --label release
-                exit 0
-              fi
-            fi
-            gh pr edit "$BRANCH" --title "$TITLE" --body-file /tmp/pr-body.md --add-label release
-            echo "Updated existing release PR for $BRANCH"
+                ;;
+            esac
           else
             gh pr create --base main --head "$BRANCH" --title "$TITLE" \
               --body-file /tmp/pr-body.md --label release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,13 +77,15 @@ jobs:
             exit 1
           fi
           # Version guard (mirror release-prep): X.Y.Z or X.Y.Z-prerelease
-          # (semver; prerelease chars [0-9A-Za-z.-]+). The version flows into
-          # an awk regex anchor below; reject metacharacters up front so a
-          # malformed package.json version cannot break the extraction (awk
-          # exit-2) after publish. '-' is a literal character in awk ERE
-          # outside a character class, so prerelease suffixes need no extra
-          # escaping there.
-          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+          # (semver; the suffix must contain at least one digit, matching
+          # parseVersion in prepare-release.mjs — digitless suffixes like
+          # 0.1.1-alpha are rejected). The version flows into an awk regex
+          # anchor below; reject metacharacters up front so a malformed
+          # package.json version cannot break the extraction (awk exit-2)
+          # after publish. '-' is a literal character in awk ERE outside a
+          # character class, so prerelease suffixes need no extra escaping
+          # there.
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]*[0-9][0-9A-Za-z.-]*)?$ ]]; then
             echo "::error::Invalid version \"$VERSION\" in package.json. Expected X.Y.Z or X.Y.Z-prerelease (e.g. 0.2.0, 0.1.1-alpha.1)."
             exit 1
           fi
@@ -195,4 +197,8 @@ jobs:
           name: v${{ steps.ver.outputs.version }}
           body_path: /tmp/notes.md
           draft: false
-          prerelease: false
+          # A version containing '-' (e.g. 0.1.1-alpha.1) is a prerelease —
+          # mark the GitHub Release as pre-release so it is never presented as
+          # the latest stable release, matching the npm prerelease dist-tag
+          # used by the publish step above.
+          prerelease: ${{ contains(steps.ver.outputs.version, '-') }}


### PR DESCRIPTION
## What

Three release-flow defects found during the 0.1.1-alpha.1 → 0.1.1 loop:

1. **MERGED release PR state** (release-prep.yml): a previously-merged release PR with the same branch name (e.g. #25 for release/v0.1.1) fell through to `gh pr edit` instead of opening a fresh PR — run 31815444523 produced no PR. Now: OPEN → edit; CLOSED → reopen-or-create; MERGED → warn + fresh create.
2. **prerelease flag** (release.yml): GitHub Release hardcoded `prerelease: false` — v0.1.1-alpha.1 was marked stable/Latest. Now `prerelease: contains(version, '-')`.
3. **Validation alignment**: workflow guards now match prepare-release.mjs exactly (suffix must contain ≥1 digit; accepts 0.1.1-alpha.1, rejects 0.1.1-alpha).

## Checks

- actionlint clean ×2; 314 tests; typecheck clean
- Defect A: 5-state shell simulation with stub gh (OPEN/CLOSED+ok/CLOSED+fail/MERGED/absent) all correct
- Defect C: node vs bash ERE equivalence verified on 8 probe cases