### PR TITLE
release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to dsh-advisor are documented here. Generated from git log by the release-prep workflow.
 
+## [0.1.2] - 2026-08-14
+
+- 0317094 Merge pull request #30 from omdsh-dev/fix/release-merge-state
+
 ## [0.1.1-alpha.1] - 2026-08-14
 
 - cd970f0 Merge pull request #26 from omdsh-dev/fix/release-oidc

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-advisor",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "description": "dsh plugin bundle porting the omp advisor subsystem: a per-session reviewer model that observes the primary transcript and injects severity-ranked advice (nit/concern/blocker).",
   "repository": {


### PR DESCRIPTION
## [0.1.2] - 2026-08-14

- 0317094 Merge pull request #30 from omdsh-dev/fix/release-merge-state


Merging this PR tags v0.1.2 and publishes dsh-advisor@0.1.2 via the Release workflow.
