### PR TITLE
fix: fail release-prep when there are no commits since the previous release

### DIFF
--- a/scripts/prepare-release.mjs
+++ b/scripts/prepare-release.mjs
@@ -3,11 +3,13 @@
  * Release-prep version helper (plan dsh-advisor-ci-release, task 2 + 4):
  * resolves the target version — explicit `X.Y.Z` / `X.Y.Z-prerelease`
  * argument (e.g. 0.1.1-alpha.1) or an auto patch bump from package.json —
- * refuses already-released versions (existing `v<version>` git tag), bumps
- * package.json, inserts the `## [<version>]` section into CHANGELOG.md (from
- * the same git-log notes the workflows use; keeps existing sections, no-op
- * when already present), and prints `VERSION=<version>` for the workflow to
- * capture. Node built-ins only, no new dependencies.
+ * refuses already-released versions (existing `v<version>` git tag), aborts
+ * when there are no commits since the previous release tag (nothing to
+ * release), bumps package.json, inserts the `## [<version>]` section into
+ * CHANGELOG.md (from the same git-log notes the workflows use; keeps
+ * existing sections, no-op when already present), and prints
+ * `VERSION=<version>` for the workflow to capture. Node built-ins only, no
+ * new dependencies.
  *
  * Usage:
  *   node scripts/prepare-release.mjs            # auto patch bump
@@ -15,8 +17,8 @@
  *   node scripts/prepare-release.mjs 0.1.1-alpha.1  # explicit prerelease
  *
  * Exit codes: 0 = bumped and printed VERSION; 1 = rejected (unparseable
- * version, existing tag, unparseable current package.json version, or
- * CHANGELOG.md write error).
+ * version, existing tag, no commits since the previous release tag,
+ * unparseable current package.json version, or CHANGELOG.md write error).
  */
 
 import { execFileSync } from 'node:child_process'
@@ -89,6 +91,19 @@ try {
   // Tag absent → OK to prepare.
 }
 
+// Fail fast on a no-change release: an empty notes range means no commits
+// since the previous release tag — prepare-release must not bump the version
+// or touch CHANGELOG.md for an empty release (no empty release PR). First-
+// ever releases (no ancestor tag yet) span the full first-parent history,
+// which is non-empty by construction, so they still pass.
+const { prevTag, notes } = resolveReleaseNotes()
+if (notes === '') {
+  console.error(
+    `Error: no commits since previous release tag ${prevTag === '' ? '<first commit>' : prevTag} — nothing to release. Aborting.`,
+  )
+  process.exit(1)
+}
+
 pkg.version = version
 // Preserve repo formatting: 2-space indent + trailing newline. The version
 // line must be the only diff (verified by `git diff package.json` in the
@@ -96,14 +111,14 @@ pkg.version = version
 writeFileSync(PKG_PATH, `${JSON.stringify(pkg, null, 2)}\n`, 'utf8')
 
 /**
- * Release notes since the previous release: first-parent commit subjects
- * between the nearest ancestor tag of HEAD and HEAD. Same snippet the
- * workflows use for the PR body — the CHANGELOG section and the PR body
- * stay consistent. When no ancestor tag exists yet, the notes span the full
- * first-parent history. Do NOT use "v$VERSION^": the version string is not a
+ * Resolve the previous release tag (nearest ancestor tag of HEAD; empty
+ * when none exists yet) and the first-parent commit subjects since that
+ * tag (full first-parent history when no tag exists). Same git-log snippet
+ * the workflows use for the PR body — the CHANGELOG section and the PR body
+ * stay consistent. Do NOT use "v$VERSION^": the version string is not a
  * git ref — the bump commit is not tagged yet.
  */
-function collectReleaseNotes() {
+function resolveReleaseNotes() {
   let prevTag = ''
   try {
     prevTag = execFileSync('git', ['describe', '--tags', '--abbrev=0', 'HEAD'], {
@@ -115,21 +130,23 @@ function collectReleaseNotes() {
     // No ancestor tag yet → full history.
   }
   const range = prevTag === '' ? 'HEAD' : `${prevTag}..HEAD`
-  return execFileSync('git', ['log', '--oneline', '--first-parent', range], {
+  const notes = execFileSync('git', ['log', '--oneline', '--first-parent', range], {
     cwd: REPO_ROOT,
     encoding: 'utf8',
     stdio: ['ignore', 'pipe', 'ignore'],
   }).trim()
+  return { prevTag, notes }
 }
 
 /**
  * Insert a `## [<version>] - <YYYY-MM-DD>` section under the `# Changelog`
- * header, above the existing sections, from the same git-log notes the
- * workflows use. Preserves all existing sections; no-op when the section for
- * this version already exists (idempotent re-runs must not duplicate it);
- * write failures exit 1.
+ * header, above the existing sections, from the pre-collected git-log notes
+ * (guaranteed non-empty by the no-change guard, so no fallback text is ever
+ * written). Preserves all existing sections; no-op when the section for this
+ * version already exists (idempotent re-runs must not duplicate it); write
+ * failures exit 1.
  */
-function updateChangelog(version) {
+function updateChangelog(version, notes) {
   let content
   try {
     content = readFileSync(CHANGELOG_PATH, 'utf8')
@@ -148,15 +165,11 @@ function updateChangelog(version) {
     return
   }
 
-  const notes = collectReleaseNotes()
   const sectionHeader = `## [${version}] - ${new Date().toISOString().slice(0, 10)}`
-  const sectionBody =
-    notes === ''
-      ? 'No commits between releases.'
-      : notes
-          .split('\n')
-          .map((line) => `- ${line}`)
-          .join('\n')
+  const sectionBody = notes
+    .split('\n')
+    .map((line) => `- ${line}`)
+    .join('\n')
   // The section's own trailing `\n` plus the inserted `\n` below form the
   // blank-line separator between the new section and the existing sections.
   const section = `${sectionHeader}\n\n${sectionBody}\n`
@@ -185,6 +198,6 @@ function updateChangelog(version) {
   }
 }
 
-updateChangelog(version)
+updateChangelog(version, notes)
 
 console.log(`VERSION=${version}`)

--- a/tests/prepare-release.test.ts
+++ b/tests/prepare-release.test.ts
@@ -111,6 +111,10 @@ function runScript(args: string[], existingTags: string[]): { status: number; st
 describe('scripts/prepare-release.mjs', () => {
   it('auto patch bump: 0.1.0 -> 0.1.1, prints VERSION=0.1.1, exits 0', () => {
     makeFixture('0.1.0')
+    // A real release has commits since the previous release: without a
+    // describe tag the notes span the full first-parent history, which must
+    // be non-empty (an empty range now fails the no-change guard).
+    writeFileSync(join(fixture, 'log-lines.txt'), 'abc1234 some commit\n', 'utf8')
     const { status, stdout, stderr } = runScript([], [])
     expect(status).toBe(0)
     expect(stdout.trim()).toBe('VERSION=0.1.1')
@@ -120,6 +124,7 @@ describe('scripts/prepare-release.mjs', () => {
 
   it('explicit version 0.2.0 is accepted and written', () => {
     makeFixture('0.1.0')
+    writeFileSync(join(fixture, 'log-lines.txt'), 'abc1234 some commit\n', 'utf8')
     const { status, stdout } = runScript(['0.2.0'], [])
     expect(status).toBe(0)
     expect(stdout.trim()).toBe('VERSION=0.2.0')
@@ -139,6 +144,43 @@ describe('scripts/prepare-release.mjs', () => {
     const { status, stderr } = runScript([], ['v0.1.1'])
     expect(status).toBe(1)
     expect(stderr).toContain('already exists')
+    expect(fixtureVersion()).toBe('0.1.0')
+  })
+
+  it('empty notes range (no commits since the previous tag) is rejected: exit 1, no file mutations', () => {
+    // (a) Realistic no-change run: a previous release tag exists but the
+    // <tag>..HEAD range has no commits (log-lines.txt absent → the git shim
+    // yields empty output). The script must fail BEFORE bumping package.json
+    // or writing CHANGELOG.md — no empty release PR can be produced.
+    makeFixture('0.1.0')
+    writeFileSync(join(fixture, 'describe-tag.txt'), 'v0.1.0\n', 'utf8')
+    const originalChangelog = [
+      '# Changelog',
+      '',
+      'All notable changes to dsh-advisor are documented here. Generated from git log by the release-prep workflow.',
+      '',
+      '## [0.1.0] - 2026-08-13',
+      '',
+      '- 9d293c0 Merge pull request #16 from dsh-external/chore/release-0.1.0',
+      '',
+    ].join('\n')
+    writeFileSync(join(fixture, 'CHANGELOG.md'), originalChangelog, 'utf8')
+    const { status, stdout, stderr } = runScript([], [])
+    expect(status).toBe(1)
+    expect(stdout).toBe('')
+    expect(stderr).toContain('Error: no commits since previous release tag v0.1.0')
+    expect(stderr).toContain('nothing to release')
+    expect(fixtureVersion()).toBe('0.1.0')
+    expect(readFileSync(join(fixture, 'CHANGELOG.md'), 'utf8')).toBe(originalChangelog)
+
+    // (b) Degenerate no-tag case (empty full first-parent history): the
+    // error names the first-commit placeholder; still no file mutations.
+    makeFixture('0.1.0')
+    const second = runScript([], [])
+    expect(second.status).toBe(1)
+    expect(second.stdout).toBe('')
+    expect(second.stderr).toContain('Error: no commits since previous release tag <first commit>')
+    expect(second.stderr).toContain('nothing to release')
     expect(fixtureVersion()).toBe('0.1.0')
   })
 
@@ -350,6 +392,7 @@ describe('scripts/prepare-release.mjs', () => {
 
   it('auto patch bump on a prerelease base drops the suffix: 0.1.1-alpha.1 -> 0.1.2', () => {
     makeFixture('0.1.1-alpha.1')
+    writeFileSync(join(fixture, 'log-lines.txt'), 'abc1234 some commit\n', 'utf8')
     const { status, stdout, stderr } = runScript([], [])
     expect(status).toBe(0)
     expect(stdout.trim()).toBe('VERSION=0.1.2')


### PR DESCRIPTION
## What

Run 31817146336 produced PR #32 (release v0.1.3) with changelog 'No commits between releases.' — auto-patch released an empty version (no commits since v0.1.2). User decision: no-change must FAIL, matching mstar-harness fragment-driven behavior (no fragment → no release).

## Change

prepare-release.mjs fails fast (exit 1, stderr message naming the previous tag) when the release-notes range is empty — BEFORE any version bump or file write. Script-side 'No commits between releases.' fallback removed (CHANGELOG section only written with real notes). Workflows untouched: 'Bump version' step already fails under set -euo pipefail on exit 1.

First-ever release (no tags, full history) unaffected; normal releases unaffected.

## Checks

- 315 tests (1 new: empty range → exit 1, no file mutations); typecheck clean
- E2E repro of run 31817146336: exit 1, package.json byte-identical, CHANGELOG not created
- 3 existing tests updated to write non-empty log fixtures (realistic release has commits)