### PR TITLE
fix: treat whitespace-only CHANGELOG as missing (bootstrap header)

### DIFF
--- a/scripts/prepare-release.mjs
+++ b/scripts/prepare-release.mjs
@@ -153,11 +153,11 @@ function updateChangelog(version, notes) {
   } catch {
     content = CHANGELOG_HEADER
   }
-  // A 0-byte CHANGELOG.md (e.g. manual truncation) is treated as missing:
-  // an empty file must still bootstrap with the standard header, otherwise
-  // the new section would land at the top with leading blank lines and no
-  // `# Changelog` header.
-  if (content === '') {
+  // A 0-byte or whitespace-only CHANGELOG.md (e.g. manual truncation) is
+  // treated as missing: such a file must still bootstrap with the standard
+  // header, otherwise the new section would land at the top with leading
+  // blank lines and no `# Changelog` header.
+  if (content.trim() === '') {
     content = CHANGELOG_HEADER
   }
 

--- a/tests/prepare-release.test.ts
+++ b/tests/prepare-release.test.ts
@@ -323,6 +323,20 @@ describe('scripts/prepare-release.mjs', () => {
     expect(changelog).toMatch(/^# Changelog\n\nAll notable changes[^\n]*\n\n## \[0\.1\.1\] - \d{4}-\d{2}-\d{2}\n\n- abc1234 some commit\n$/)
   })
 
+  it('CHANGELOG.md: whitespace-only file is bootstrapped like a missing file (header + section, no leading blank lines)', () => {
+    makeFixture('0.1.0')
+    writeFileSync(join(fixture, 'log-lines.txt'), 'abc1234 some commit\n', 'utf8')
+    // An existing-but-whitespace-only CHANGELOG.md must take the missing-file
+    // path too: pre-fix, the append branch produced a headerless file that
+    // starts with blank lines instead of `# Changelog`.
+    writeFileSync(join(fixture, 'CHANGELOG.md'), '\n\n  \n', 'utf8')
+    const { status } = runScript(['0.1.1'], [])
+    expect(status).toBe(0)
+    const changelog = readFileSync(join(fixture, 'CHANGELOG.md'), 'utf8')
+    expect(changelog.startsWith('# Changelog\n')).toBe(true)
+    expect(changelog).toMatch(/^# Changelog\n\nAll notable changes[^\n]*\n\n## \[0\.1\.1\] - \d{4}-\d{2}-\d{2}\n\n- abc1234 some commit\n$/)
+  })
+
   it('CHANGELOG.md: nearest ancestor tag — notes use the <tag>..HEAD range and the section lists only post-tag commits', () => {
     makeFixture('0.1.0')
     // The fake git shim echoes `git describe` from describe-tag.txt and


### PR DESCRIPTION
## What

prepare-release.mjs guarded only 0-byte CHANGELOG.md; a whitespace-only file was treated as normal → new section landed without `# Changelog` header / with leading blank lines. Recorded nit from qc3-t4 re-review.

## Change

- `content === ''` → `content.trim() === ''` (whitespace-only bootstraps header like missing/0-byte)
- Regression test: whitespace-only fixture → exit 0, file starts with `# Changelog`, section present

## Checks

- 316 tests (1 new); typecheck clean; 2 files surgical