### PR TITLE
fix: auto-bump stays on the prerelease line (sibling semantics)

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -31,7 +31,7 @@
 >
 > **发布触发标准：仅当合并内容包含实质变更（代码 / 行为 / 用户可见的文档或配置变更）时才发起发布；纯注释、格式化、工作流注释等 trivial 变更直接合入 main，随下一个实质版本一起发布（空范围守卫只拦截零提交，不拦截 trivial 提交）。判断标准由维护者把握。**
 
-- **留空 = 自动 patch**：`scripts/prepare-release.mjs` 读取当前 `package.json` 版本并把 patch 位 +1，同时**丢弃 prerelease 后缀**（`0.1.3-alpha.1` → `0.1.4`）。**注意**：自动 patch 产出的是**正式版本号**——alpha 规则生效期间，留空会绕过 alpha 规则发出正式版本，因此**必须显式填写 alpha 版本**（如 `0.1.4-alpha.1`），不要留空。
+- **留空 = 自动 patch**：`scripts/prepare-release.mjs` 读取当前 `package.json` 版本：正式版本（无 prerelease）patch 位 +1（`0.1.2` → `0.1.3`）；prerelease 版本在**原 prerelease 线上自增**（`0.1.3-alpha.3` → `0.1.3-alpha.4`，保持 alpha 线，不会丢后缀退化为正式版本）；非数字 prerelease 尾（如 `0.1.0-alpha`）无法自动自增，会报错并提示显式填写版本。
 - **显式版本**：在 `version` 输入框填写完整 semver，支持 `X.Y.Z`（如 `0.2.0`、`1.0.0`）与 `X.Y.Z-alpha.N`（如 `0.1.4-alpha.1`）。需要 minor / major 升级、或想跳过中间 patch 版本时用这个方式；alpha 规则生效期间一律用 `X.Y.Z-alpha.N` 形式。
 - **prerelease 不污染 `latest`**：`X.Y.Z-alpha.N` 发布到 `alpha` dist-tag（`npm install dsh-advisor@alpha` 可安装），不会更新 `latest`；只有正式版本 `X.Y.Z` 才会更新 `latest`。
 - **空版本范围会被拒绝**：若自上一个 release tag 以来没有新提交（没有可发布内容），Release prep 会直接报错退出（exit 1），不会产生空版本 / 空发布 PR。

--- a/scripts/prepare-release.mjs
+++ b/scripts/prepare-release.mjs
@@ -63,16 +63,42 @@ if (process.argv[2] !== undefined) {
     process.exit(1)
   }
 } else {
-  const current = parseVersion(pkg.version)
-  if (current === null) {
+  // Auto patch bump (mirrors sibling dsh-llm-fallbacks autoBumpPatch): parse
+  // the current version as X.Y.Z or X.Y.Z-pre, then:
+  //  - formal version X.Y.Z            -> X.Y.(Z+1)       (0.1.2 -> 0.1.3)
+  //  - prerelease with numeric tail    -> bump only the tail, staying on the
+  //    prerelease line (0.1.3-alpha.3 -> 0.1.3-alpha.4)
+  //  - prerelease with non-numeric tail (e.g. 0.1.0-alpha) -> cannot auto
+  //    bump; require an explicit version argument.
+  // The looser regex is deliberate: parseVersion (explicit args) requires a
+  // digit in the suffix, so it cannot tell "alpha" from a malformed version;
+  // this path needs the raw suffix to reject non-numeric tails with the
+  // explicit-version hint.
+  const m = /^(\d+)\.(\d+)\.(\d+)(?:-(.+))?$/.exec(pkg.version)
+  if (!m) {
     console.error(`Error: cannot parse current package.json version "${pkg.version}".`)
     process.exit(1)
   }
-  // Auto patch bump: bump the numeric patch part and DROP any prerelease
-  // suffix (a prerelease base 0.1.1-alpha.1 with no explicit arg -> 0.1.2,
-  // i.e. the next formal patch after the 0.1.1 line). An explicit prerelease
-  // argument is the way to prepare another prerelease (e.g. 0.1.1-alpha.2).
-  target = { major: current.major, minor: current.minor, patch: current.patch + 1 }
+  const [, major, minor, patch, pre] = m
+  if (pre === undefined) {
+    target = { major: Number(major), minor: Number(minor), patch: Number(patch) + 1 }
+  } else {
+    const tail = pre.split('.').at(-1)
+    if (tail === undefined || !/^\d+$/.test(tail)) {
+      console.error(
+        `Error: cannot auto-bump "${pkg.version}": prerelease tail "${pre}" is not numeric. ` +
+          'Pass an explicit version instead (e.g. `node scripts/prepare-release.mjs 0.1.1-alpha.1`).',
+      )
+      process.exit(1)
+    }
+    const prefix = pre.slice(0, pre.length - tail.length) // "alpha." for "alpha.1"
+    target = {
+      major: Number(major),
+      minor: Number(minor),
+      patch: Number(patch),
+      prerelease: `${prefix}${Number(tail) + 1}`,
+    }
+  }
 }
 
 const version =

--- a/tests/prepare-release.test.ts
+++ b/tests/prepare-release.test.ts
@@ -404,14 +404,52 @@ describe('scripts/prepare-release.mjs', () => {
     expect(changelog.slice(changelog.indexOf('## [0.1.0]'))).toBe(originalSectionText)
   })
 
-  it('auto patch bump on a prerelease base drops the suffix: 0.1.1-alpha.1 -> 0.1.2', () => {
+  it('auto patch bump on a prerelease base stays on the prerelease line: 0.1.1-alpha.1 -> 0.1.1-alpha.2', () => {
+    // Sibling dsh-llm-fallbacks semantics: a prerelease current version auto
+    // bumps WITHIN its prerelease line (bumping only the numeric tail) —
+    // it must never drop the suffix to a stable version, which would bypass
+    // the alpha-only release rule.
     makeFixture('0.1.1-alpha.1')
     writeFileSync(join(fixture, 'log-lines.txt'), 'abc1234 some commit\n', 'utf8')
     const { status, stdout, stderr } = runScript([], [])
     expect(status).toBe(0)
-    expect(stdout.trim()).toBe('VERSION=0.1.2')
+    expect(stdout.trim()).toBe('VERSION=0.1.1-alpha.2')
     expect(stderr).toBe('')
-    expect(fixtureVersion()).toBe('0.1.2')
+    expect(fixtureVersion()).toBe('0.1.1-alpha.2')
+  })
+
+  it('auto patch bump on a formal version: 0.1.2 -> 0.1.3', () => {
+    makeFixture('0.1.2')
+    writeFileSync(join(fixture, 'log-lines.txt'), 'abc1234 some commit\n', 'utf8')
+    const { status, stdout, stderr } = runScript([], [])
+    expect(status).toBe(0)
+    expect(stdout.trim()).toBe('VERSION=0.1.3')
+    expect(stderr).toBe('')
+    expect(fixtureVersion()).toBe('0.1.3')
+  })
+
+  it('auto patch bump on a prerelease base: 0.1.3-alpha.3 -> 0.1.3-alpha.4', () => {
+    makeFixture('0.1.3-alpha.3')
+    writeFileSync(join(fixture, 'log-lines.txt'), 'abc1234 some commit\n', 'utf8')
+    const { status, stdout, stderr } = runScript([], [])
+    expect(status).toBe(0)
+    expect(stdout.trim()).toBe('VERSION=0.1.3-alpha.4')
+    expect(stderr).toBe('')
+    expect(fixtureVersion()).toBe('0.1.3-alpha.4')
+  })
+
+  it('auto patch bump on a non-numeric prerelease tail is rejected: 0.1.0-alpha -> exit 1', () => {
+    // The tail must be numeric to auto-bump (sibling semantics); a digitless
+    // suffix like "alpha" cannot be incremented, so the script demands an
+    // explicit version instead — no file mutations.
+    makeFixture('0.1.0-alpha')
+    writeFileSync(join(fixture, 'log-lines.txt'), 'abc1234 some commit\n', 'utf8')
+    const { status, stdout, stderr } = runScript([], [])
+    expect(status).toBe(1)
+    expect(stdout).toBe('')
+    expect(stderr).toContain('prerelease tail "alpha" is not numeric')
+    expect(stderr).toContain('Pass an explicit version')
+    expect(fixtureVersion()).toBe('0.1.0-alpha')
   })
 
   it('invalid prerelease versions are rejected: exit 1 + stderr message, package.json untouched', () => {


### PR DESCRIPTION
## What

Aligned auto-bump with sibling repo dsh-llm-fallbacks: a prerelease current version auto-bumps WITHIN its prerelease line, never dropping to a stable version.

## Change

- **prepare-release.mjs**: auto-patch now mirrors sibling `autoBumpPatch` — stable → patch+1 (0.1.2 → 0.1.3); prerelease numeric tail → tail+1 on same line (0.1.3-alpha.3 → 0.1.3-alpha.4); non-numeric tail → exit 1 with explicit-version hint
- **tests**: updated 1 + added 3 (stable bump / prerelease line bump / non-numeric tail error) — 319 total
- **docs/release.md §3**: auto-patch bullet rewritten; old 'auto-patch produces stable version' warning removed (no longer true)

## Why

Serves the alpha-only rule: empty input (auto) stays on the alpha line, cannot accidentally publish a stable version.

## Checks

- 319 tests, typecheck clean; no workflow changes (publish --tag alpha path untouched)