### PR TITLE
release v0.1.3-alpha.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to dsh-advisor are documented here. Generated from git log by the release-prep workflow.
 
+## [0.1.3-alpha.4] - 2026-08-14
+
+- 2c69834 Merge pull request #41 from omdsh-dev/fix/prerelease-auto-bump
+- b78fb4c Merge pull request #40 from omdsh-dev/docs/release-trigger-policy
+- 1fd4c62 Merge pull request #39 from omdsh-dev/fix/release-comment-parity
+
 ## [0.1.3-alpha.3] - 2026-08-14
 
 - 4b1f484 Merge pull request #37 from omdsh-dev/fix/changelog-whitespace

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-advisor",
-  "version": "0.1.3-alpha.3",
+  "version": "0.1.3-alpha.4",
   "type": "module",
   "description": "dsh plugin bundle porting the omp advisor subsystem: a per-session reviewer model that observes the primary transcript and injects severity-ranked advice (nit/concern/blocker).",
   "repository": {


### PR DESCRIPTION
## [0.1.3-alpha.4] - 2026-08-14

- 2c69834 Merge pull request #41 from omdsh-dev/fix/prerelease-auto-bump
- b78fb4c Merge pull request #40 from omdsh-dev/docs/release-trigger-policy
- 1fd4c62 Merge pull request #39 from omdsh-dev/fix/release-comment-parity


Merging this PR tags v0.1.3-alpha.4 and publishes dsh-advisor@0.1.3-alpha.4 via the Release workflow.
