### PR TITLE
fix: cross-check PR title vs package.json version, explicit provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,25 @@ jobs:
         id: ver
         run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
 
+      # The Release prep workflow derives the version from the PR title
+      # ("release v<version>") and bumps package.json to match. If the merged
+      # PR drifted from that contract (e.g. the version was edited inside the
+      # PR without re-running prep), publishing the drifted version would
+      # silently produce a mismatched tag and an empty GitHub Release — fail
+      # loudly instead.
+      - name: Cross-check version vs PR title
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+          TITLE_VER="${TITLE#release v}"
+          if [ "$TITLE_VER" != "$VERSION" ]; then
+            echo "::error::PR title version \"${TITLE_VER}\" does not match package.json version \"${VERSION}\". Re-run Release prep for v${VERSION} instead of hand-editing the PR."
+            exit 1
+          fi
+          echo "PR title and package.json agree on ${VERSION}"
+
       - name: Validate version
         env:
           VERSION: ${{ steps.ver.outputs.version }}
@@ -127,12 +146,15 @@ jobs:
           # instead of the default `latest`, so prereleases never clobber the
           # latest release and consumers opting into the tag can install it.
           # Formal X.Y.Z versions publish without --tag (default latest).
+          # --provenance is explicitly requested: it makes sigstore signing
+          # deterministic under OIDC trusted publishing (matches the sibling
+          # dsh-llm-fallbacks release workflow).
           if [[ "${VERSION}" == *-* ]]; then
             PRETAG="${VERSION#*-}"
             PRETAG="${PRETAG%%.*}"
-            npm publish --access public --tag "$PRETAG"
+            npm publish --provenance --access public --tag "$PRETAG"
           else
-            npm publish --access public
+            npm publish --provenance --access public
           fi
 
       - name: Configure git identity

--- a/docs/release.md
+++ b/docs/release.md
@@ -19,9 +19,9 @@
 
 合并 `release vX.Y.Z` PR 后，**Release** 工作流在 `pull_request`（closed）事件上运行，按顺序自动执行：
 
-1. **校验**：检出合并提交（`merge_commit_sha`），读取 `package.json` 版本号并确认非空。
+1. **校验**：检出合并提交（`merge_commit_sha`），读取 `package.json` 版本号并确认非空；同时校验 PR 标题版本与 package.json 版本一致（防手改 PR 导致 tag/Release 错配）。
 2. **构建**：`pnpm run typecheck && pnpm run build && pnpm run test`（与 CI 相同的校验命令）。
-3. **发布**：`npm publish --access public`，向 npm 发布 `dsh-advisor@X.Y.Z`（认证走 OIDC trusted publishing，无需任何 secret）。版本号含 `-` 的 prerelease（如 `0.1.3-alpha.1`）自动带 `--tag <前缀>`（前缀 = 首个 `-` 之后到首个 `.` 之前的文本，如 `alpha`），发布到 `alpha` dist-tag；正式版本（`X.Y.Z`）不带 `--tag`，默认发布到 `latest`。
+3. **发布**：`npm publish --provenance --access public`，向 npm 发布 `dsh-advisor@X.Y.Z`（认证走 OIDC trusted publishing，无需任何 secret；`--provenance` 显式请求 sigstore 签名，与 dsh-llm-fallbacks 一致）。版本号含 `-` 的 prerelease（如 `0.1.3-alpha.1`）自动带 `--tag <前缀>`（前缀 = 首个 `-` 之后到首个 `.` 之前的文本，如 `alpha`），发布到 `alpha` dist-tag；正式版本（`X.Y.Z`）不带 `--tag`，默认发布到 `latest`。
 4. **打 tag**：以 `github-actions[bot]` 身份创建并推送注解 tag `vX.Y.Z`（commit message `Release vX.Y.Z`）；若该 tag 已存在，tag 步骤会跳过。**tag 跳过只覆盖 tag**——npm 不允许重复发布同一版本（`npm error ... previously published versions`），因此重跑工作流只在 **`npm publish` 步骤本身失败**（尚未发布任何版本、也未创建 tag）时才能继续完成发布；如果发布已经成功（例如随后 tag 或 GitHub Release 步骤失败），重跑会在 `npm publish` 步骤失败，而不是照常发布。**注意「已发布但未打 tag」的缺口**：发布成功后若 tag 步骤失败，仓库中没有任何 `vX.Y.Z` tag（基于 tag 的重复版本检查也拦不住该版本），此时重跑会卡在 `npm publish`；恢复只能人工处理——用 `gh release create vX.Y.Z --generate-notes`（或 `gh release create` 手动编辑正文）为已发布版本补建 tag 与 GitHub Release，或 bump 一个新版本重新走发布流程。
 5. **创建 GitHub Release**：以 `vX.Y.Z` 为 tag 与标题创建 Release，正文取自 `CHANGELOG.md` 中对应版本的 `## [X.Y.Z]` 小节（该小节由 **Release prep** 写入并随发布 PR 提交），仅包含该小节本身；PR 正文取自同一小节（提取来源相同），并额外附一行合并说明（见 [§1 步骤 4](#1-发布流程)）。版本号含 `-`（如 `0.1.3-alpha.1`）时，该 Release 会被标记为 **Pre-release**，不会作为最新稳定版展示。若该小节缺失（例如在引入 `CHANGELOG.md` 之前准备的旧发布 PR），则回退为自上一个 tag 以来的提交记录（`git log --oneline --first-parent`，取最近祖先 tag 为基准；无 tag 时为完整历史）。注：在 `CHANGELOG.md` 引入之前就已打开的在途发布 PR（例如本次变更时在途的 0.1.1 PR）合并后，其 Release 正文经回退逻辑以 git-log 格式生成，且该版本不会在 `CHANGELOG.md` 中留下小节（同版本不可重复准备）；从下一个版本起，Release 正文恢复为对应 `## [X.Y.Z]` 小节。
 


### PR DESCRIPTION
## What

Two non-controversial release-flow alignments with sibling dsh-llm-fallbacks:

1. **Cross-check version vs PR title** (release.yml): fail loudly if PR title version ≠ package.json version — a hand-edited release PR would otherwise silently produce a mismatched tag and empty GitHub Release
2. **Explicit `--provenance`** on both publish commands (deterministic sigstore signing under OIDC; sibling uses it)

Dist-tag strategy untouched (`--tag alpha` isolation, per user decision).

## Checks

- actionlint clean; 319 tests; typecheck clean
- Shell simulation: matching title exit 0 / mismatching exit 1 with clear error