### PR TITLE
release v0.1.3-alpha.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to dsh-advisor are documented here. Generated from git log by the release-prep workflow.
 
+## [0.1.3-alpha.5] - 2026-08-15
+
+- 79a07f2 Merge pull request #43 from omdsh-dev/fix/release-crosscheck
+
 ## [0.1.3-alpha.4] - 2026-08-14
 
 - 2c69834 Merge pull request #41 from omdsh-dev/fix/prerelease-auto-bump

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-advisor",
-  "version": "0.1.3-alpha.4",
+  "version": "0.1.3-alpha.5",
   "type": "module",
   "description": "dsh plugin bundle porting the omp advisor subsystem: a per-session reviewer model that observes the primary transcript and injects severity-ranked advice (nit/concern/blocker).",
   "repository": {


### PR DESCRIPTION
## [0.1.3-alpha.5] - 2026-08-15

- 79a07f2 Merge pull request #43 from omdsh-dev/fix/release-crosscheck


Merging this PR tags v0.1.3-alpha.5 and publishes dsh-advisor@0.1.3-alpha.5 via the Release workflow.
