### PR TITLE
docs: add configuration / consumer-api / verification guides

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,114 @@
+# 配置指南（`advisor` 命名空间）
+
+`dsh-advisor` 的配置集中在 `advisor` settings 命名空间。它有两个持久化配置面，读写同一组键：
+
+1. **插件行 config** —— 用户 profile 的 `cordis.patch.yml`（如 `profiles/web/cordis.patch.yml`）里 `id: advisor` 那一行的 `config` 字段。这是合成的 **base**（`src/settings.ts` `installAdvisorSettings` 以 entry 为 `base` 注册命名空间）。
+2. **web Settings —— "插件配置"页的 Advisor 卡片**（`id advisor`，渲染在三张上游卡片 bash / agent-loop / web-search 之后）—— 卡片把编辑结果写入 `advisor` 命名空间的 **user layer**，覆盖插件行 config 而无需改动它；保存后新会话立即生效，无需重启（运行时 live 读取合成值，见 [live 重应用](#live-重应用)）。
+
+卡片对配置的读写**只**走官方 `GatewayService` RPC 通道：`/api/advisor/get` + `/api/advisor/set`（`src/gateway.ts` 的 `AdvisorConfigGateway`，由宿主 typertGateway 认领，与 dsh 内建 `goals` 服务同一机制）。`advisor` 命名空间**不在**宿主 apiproxy 的 exposed-namespaces 白名单上（上游 dsh 没有注册级 opt-in），因此该通道也不受 settings 暴露白名单门控；进程内写入（`ctx.settings.update`）没有 exposed-namespace 检查。没有 settings service 时，source 就是插件行 entry，行为与未装插件时一致（`src/settings.ts`）。**插件不做任何宿主补丁**。
+
+第三个控制面 `/advisor` 指令是**会话级且临时**的（翻转的是按会话的 override，从不修改持久化配置）——见 [消费者契约](consumer-api.md#advisor-指令面) 与 [用法](../README.zh.md#用法)。
+
+## 配置字段
+
+字段契约定义在 `src/config.ts`（`AdvisorConfig` 接口 + `Config` Loader schema）。`Config` 是 schemastery schema，由 cordis Loader 用来校验插件行并施加默认值与类型/边界（整数 ≥ 0）。
+
+| 键 | 类型 | 默认值 | 含义 |
+|---|---|---|---|
+| `enabled` | boolean | `false` | 总开关。`false` 时插件不干预任何会话。 |
+| `provider` | string（可选） | 未设置 | 供应商路由。**`enabled: true` 时必须（非空）** —— 见 [显式模型门禁](#显式模型门禁s4)。 |
+| `model` | string（可选） | 未设置 | 模型 id。**`enabled: true` 时必须（非空）** —— 见 [显式模型门禁](#显式模型门禁s4)。 |
+| `systemPrompt` | string | `""` | 覆盖内置评审 prompt（严重度定义 + JSON-frame 输出契约，`src/prompts.ts` `DEFAULT_ADVISOR_SYSTEM_PROMPT`）。`""` = 用内置。 |
+| `immuneTurns` | number（整数 ≥ 0） | `3` | 冷却步数：实际 steer 过一次 concern/blocker 后，接下来 N 个完成的 stepped 主 turn 必须走完，另一条打断性 note 才可再次 steer；窗口内的 note 降级为 inject。 |
+| `maxDeltaMessages` | number（整数 ≥ 0） | `60` | 有界的 advisor 输入窗口。超过 N 的 delta 以 `… <earlier messages omitted>` 标记截断；`0` = 无上限。 |
+
+> 默认值即 `Config` schema 的默认值（`z.boolean().default(false)`、`z.string().default('')`、`z.number().step(1).min(0).default(3)` / `.default(60)`，`src/config.ts`）。`provider` / `model` 在 schema 上没有默认值 —— 保持可选是为了让 enabled-without-pair 的配置能通过 Loader 校验、再由门禁解析为 disabled-with-reason（而不是加载失败）。
+
+### 示例 YAML
+
+```yaml
+# profiles/web/cordis.patch.yml — profile 的 user patch layer
+- id: advisor
+  config:
+    enabled: true               # 总开关（默认 false）
+    provider: deepseek-official # enabled: true 时必填（非空）
+    model: deepseek-v4-flash    # enabled: true 时必填（非空）
+    systemPrompt: ""            # 可选；"" = 内置评审 prompt
+    immuneTurns: 3              # 整数 ≥ 0，默认 3 —— 打断性送达后的冷却步数
+    maxDeltaMessages: 60        # 整数 ≥ 0，默认 60 —— delta 窗口；0 = 无上限
+```
+
+## 显式模型门禁（S4）
+
+`enabled: true` 而 `provider` 或 `model` **缺失或为空（含全空白字符串）** 时，`resolveAdvisorConfig`（`src/config.ts`）把配置解析为 **disabled-with-reason**：`enabled: false` + `disabledReason`，**绝不发起任何模型调用**（硬门禁，不是警告）。这是所有路径的 SSOT：
+
+- 运行时每次读取都经过该解析器（`src/index.ts` `safeResolved` / `safeEffective`），因此 settings 编辑也永远无法绕过门禁发起模型调用；
+- `/advisor status` 与 `/advisor on` 的回复在门禁阻挡时展示原因（`src/commands.ts`）；
+- Settings 卡片在 enabled 且必填字段为空时阻止保存，但宿主侧硬门禁始终是最后防线。
+
+**未知键严格拒绝**：`resolveAdvisorConfig` 显式拒绝未知键（`CONFIG_KEYS` 白名单，`src/config.ts`）与非对象输入；插件行加载时未知键抛错、拒绝该行（`src/index.ts` 构造期读取仍用抛错版 `resolved()`）。settings 的 user layer 若写入了解析器拒绝的值（如未知键），live 读取会解析为 disabled-with-reason 携带错误信息 —— 永不 wedge 热路径、永不启动模型调用（`src/index.ts` `safeFallback`；`src/gateway.ts` `readConfig` 同样包含该 containment）。
+
+## 合成模型（composition）
+
+三个来源按「后一层覆盖前一层」合成，各处使用同一组键（`src/settings.ts`）：
+
+```text
+schema 默认值 → 插件行 config（base）→ settings user layer（web 卡片写入）
+```
+
+- 无 settings service（未组合 `settings` 时，条件 `ctx.inject(['settings'], ...)` 子项不激活）→ source 恰为插件行 entry；
+- 有 settings service → `AdvisorSettingsBridge.source()` 读 scope 的 live 合成值；每次 committed 变更触发 `onChange`。
+
+## 行为要点
+
+### 严重度与送达语义（spec §6）
+
+每次评审至多发出一条 note，带严重度等级（`src/advisor-runtime.ts` `AdviceSeverity` = `'nit' | 'concern' | 'blocker'`）：
+
+| 严重度 | 含义 | 送达通道 |
+|---|---|---|
+| `nit` | 轻微的风格 / 清晰度 / 质量建议，无需改变方向 | `agent.inject`（**非唤醒**，下一个 pre-step 边界消费） |
+| `concern` | 值得在继续前权衡的重大风险或明显更优的方向 | `agent.steer`（**唤醒**），受 `immuneTurns` 冷却约束 |
+| `blocker` | 继续下去明显浪费工作（与显式用户指令矛盾、原地打转、根本性不可行） | `agent.steer` |
+
+送达消息是 user-role 消息，携带 advisor source kind（`src/kinds.ts` `ADVISOR_SOURCE_KIND`）与自我描述内容 `[advisor:{severity}] {note}`（`src/delivery.ts` `buildAdvisorMessage`；`form: 'notice'`，summary 有界 120 字符）—— 这是主模型获得的唯一关于如何对待它的线索。advisor 消息被排除在此后的 advisor delta 之外（自审排除，见下）。
+
+**`immuneTurns` 冷却**（`src/delivery.ts` `AdvisorDelivery`）：仅在一条 concern/blocker **实际 steer 送达**后武装冷却栅栏；接下来 `immuneTurns` 个完成的 stepped 主 turn 走完之前，新的打断性 note 降级为 inject；`onSteppedTurnEnd`（每个完成的 stepped 可评审 turn/end）驱动倒计时。compaction / surface 重写（KD-5）清空栅栏。缺 agent 时 note 丢弃并记日志 —— advisory only，永不 throw、永不 stall。
+
+### 评审运行策略（`src/advisor-runtime.ts`）
+
+- 每个会话一个 `AdvisorRuntime`；delta 进有界 FIFO 队列（默认 32，满时丢最新并记日志），串行异步 drain —— **主循环永不被 park**；
+- 每次 `llm.stream` 调用：`{ provider, model, system, messages: [user delta], maxTokens: 5120 }`（5120 = 用户指示的 256 → 5120 的 20 倍预算；`purpose` 不设置，KD-5）。`reasoningEffort: 'off'` 仅在所配置模型的 adapter 声明该档位时发送（`src/advisor-runtime.ts` `resolveModelInfo` 能力查询）；
+- 每次调用有 60s 整调用 deadline（超时按 transient 处理，KD-5 retry → drop）；
+- **failure policy（KD-5）**：transient → 1 次重试（1s backoff）→ drop；连续 3 次 drop → 冲刷积压 backlog（不 stall）；quota/rate-limit → `quota_exhausted` 暂停（批次保留，**无自动恢复定时器** —— `/advisor on` 手动恢复）；permanent（`invalid_request_error` / model-not-found / "is not supported when" / does not exist）→ `halted`（原地终止；`/advisor on` 为该会话全新重建）；
+- **KD-2 抽取**：解析回复中第一个平衡 JSON 帧（容忍 prose/fence）为 `{note, severity}`；`note` 非空否则 drop+log；`severity` 缺失/非法默认 `nit`；不做解析重试；note 文本有界（1000 字符，`ADVISOR_NOTE_MAX_CHARS`）；
+- **T5 emission guard**（`src/emission-guard.ts`）：normalize（等价拼写归一到同一身份）、content-free 短语抑制（stop / done / complete / no issue continue / lgtm / nothing to add）、跨 update 去重（允许 nit → concern → blocker 升级）、每次 update 至多一条 note、FIFO 有界去重历史（默认 4096）；compaction / surface 重写清空历史与 latch。
+
+### 双模式触发与自审排除（`src/transcript.ts`）
+
+- **标准 stepped 会话**：每个正常结束（`reason.kind ∈ {completed, 'max-tokens', error}`）的 stepped 主 turn/end 之后评审增量 delta；跳过 `aborted` / `blocked` / `interrupted`（不评审被用户截断的 turn）；
+- **agentic / harness 会话**（从不发出 `turn/end`）：每个完成的 agent 回复轮次后 —— 当新的用户输入（含 `agent/inbox/spliced` 拼接的用户输入）在未评审的 assistant 增量之后到达时评审；非用户 inbox 拼接（advisor 自己的 inject/steer 送达等）永不触发（C-1 自触发修复）；
+- **自审排除**：advisor-source 消息永不被渲染进 advisor delta，advisor 不会读回自己的建议；
+- `maxDeltaMessages` 有界窗口（`DeltaRenderer`）；compaction / surface replace / 指纹不匹配 → 重置游标、全量重放（KD-5）。
+
+### Live 重应用
+
+Settings 每次 committed 变更经 `bridge.onChange` 重派生（`src/index.ts`）：`immuneTurns` / `maxDeltaMessages` 原地更新（delivery / observer）；每个会话 runtime 仅在其「运行影响签名」（enabled / provider / model / systemPrompt）变化时重建 —— 只改免疫/窗口的编辑不会中断在途调用或丢弃 backlog；config 级开关跟随 live source，新会话立即生效。S4 门禁每次读取都经解析器重放，settings 编辑永远无法启动被门禁阻挡的模型调用。
+
+## Web 卡片行为（`src/client`）
+
+Advisor 卡片（`id advisor`，order 30，`src/client/index.ts` 注册进 `settings.plugin.item` slot）的行为契约：
+
+- **enabled 开关**（默认 OFF）：关闭时显示配置表单被隐藏的提示，进行中的草稿保留；
+- **provider / model 选择框**：只列出**已配置**的 provider（命名空间 + profile 均解析，KD-S2）；model 选项优先取 provider profile 的声明模型，否则回退 `llm.models` catalog；存储的 provider/model 不再可用时显示警告；join 为空时显示引导文案；
+- **systemPrompt** 文本框（placeholder 提示空 = 默认）、`immuneTurns` / `maxDeltaMessages` 数字输入（清空数字输入保持空、不强制为 0）；
+- **保存**经网关 `set`（`connection.rpc.call('/api', 'advisor/set', { patch })`）：只把相对上次读取的**变更键**作为 patch 发送；`set` 先经 `Config` schema 校验（未知键拒绝）再写 user layer，返回新合成值；
+- **降级态**：网关不可达 → 卡片头部显示 config-channel 提示且不提供 Save；加载失败 → 头部提示 + 可重试；settings provider 只读 → 只读提示并禁用写入；
+- 卡片**没有** reset-to-defaults 动作（网关只暴露 `get` / `set` 两个端点）。
+
+## 相关文档
+
+- [消费者契约](consumer-api.md) — 包根导出、客户端入口、`/advisor` 指令面
+- [验证记录](verification.md) — 测试矩阵与真实环境验证步骤
+- [安装指南](install.zh.md) — 安装 / 验证 / 卸载
+- [README（配置与用法）](../README.zh.md)

--- a/docs/consumer-api.md
+++ b/docs/consumer-api.md
@@ -1,0 +1,84 @@
+# 消费者契约（Consumer API）
+
+本文定义 `dsh-advisor` 暴露的**消费者表面**：(1) 包根库 API（`import { … } from 'dsh-advisor'`）；(2) 客户端入口（`dsh-advisor/client`，web 注入的 Advisor 卡片）；(3) `/advisor` 指令面（按会话控制）。安装 → [docs/install.zh.md](install.zh.md)；发布流程 → [docs/release.md](release.md)。
+
+> **契约边界**：本文描述的是**本包**的导出表面与生命周期。**有效的包契约 ≠ 集成完成的下游仓库** —— 集成是否完整必须以目标仓库里的实际 wiring 为准。
+
+## 包根导出（`src/index.ts`）
+
+`src/index.ts` 是 cordis 插件入口（bundle 组合包的宿主半），从包根统一导出：
+
+```ts
+import { name, inject, Config, apply } from 'dsh-advisor'
+import type { AdvisorConfig, ResolvedAdvisorConfig } from 'dsh-advisor'
+```
+
+| 导出 | 类型 | 说明 |
+|---|---|---|
+| `name` | `'dsh-advisor'`（string 常量） | 插件名。 |
+| `inject` | `['sessions', 'agents', 'llm']` | 插件消费的服务；行在全部可用后加载。 |
+| `Config` | schemastery schema（value） | Loader schema（严格：默认值 + 类型/边界校验），由 cordis Loader 校验插件行 config。见 [配置指南](configuration.md#配置字段)。 |
+| `AdvisorConfig` | type | 插件行 config 契约（`enabled` / `provider` / `model` / `systemPrompt` / `immuneTurns` / `maxDeltaMessages`）。 |
+| `ResolvedAdvisorConfig` | type | 显式模型门禁（S4）之后的运行时契约（含可选的 `disabledReason`）。 |
+| `apply(ctx, config)` | function | 插件 apply：安装 `advisor` settings 命名空间（条件 `ctx.inject(['settings'], ...)`）、注册 `AdvisorConfigGateway` 与 typert 端点（条件 `ctx.inject(['typert'], ...)`）、组合 observer / runtime / delivery、在组合 command registry 时注册 `/advisor` 指令（条件 `ctx.inject(['commands'], ...)`）。 |
+
+> 包根**没有**按函数粒度重导出内部运行函数（如 `resolveAdvisorConfig` 不在包根导出面内 —— 它由 `src/config.ts` 内部使用；包根的运行时导出面就是 `name` / `inject` / `Config` / `apply`，类型面是 `AdvisorConfig` / `ResolvedAdvisorConfig`）。这与按「纯函数库」设计的插件不同 —— `dsh-advisor` 是组合包（bundle），不是函数库；内部模块（`src/advisor-runtime.ts`、`src/delivery.ts`、`src/commands.ts` 等）是 cordis-free 的实现单元，通过 `apply` 的 wiring 消费，不在包根暴露。
+
+### 包导出映射（`package.json` `exports`）
+
+| 入口 | 解析 |
+|---|---|
+| `dsh-advisor`（`.`） | `lib/index.js`（types `lib/index.d.ts`）—— 宿主半插件入口 |
+| `dsh-advisor/client`（`./client`） | `lib/client.js`（types `lib/client.d.ts`）—— 浏览器半（web 卡片） |
+| `dsh-advisor/package.json` | 元数据 |
+
+发布物（`files`）为 `lib/` + `cordis.patch.yml` + `scripts/`；`cordis.patch.yml` 插入一行插件配置 —— `id: advisor`，`name: dsh-advisor`。运行时依赖全部声明为 peerDependencies（`@deepseek-ai/cordis` / `@deepseek-ai/schemastery` / `@deepseek-ai/dsh-*` / `react`），由 dsh 安装的扁平 profile module fallback 解析。
+
+## cordis 服务键 `'advisor'`
+
+`apply` 在 try/catch 中构造 `AdvisorConfigGateway`（`src/gateway.ts`），它以 cordis 服务键 **`'advisor'`** 注册（`TypertRemoteService` 基类）。这是 `/api/advisor/*` RPC 端点的**调度目标**（typertGateway 经 `ctx.get('advisor')` 分发）—— **不是**面向消费者的公共 API：它不暴露可调用的纯函数面，也没有稳定对象契约可依赖。跨插件需要读取 advisor 状态时，应使用文档化的面（`/api/advisor/get`、`/advisor status`），而不是读取该服务对象的内部。
+
+多 fiber 去重：宿主会组合多个 `dsh-advisor` fiber（观察到的典型情况是 3 个）。settings 命名空间与 `advisor` 服务键的注册都是「先注册者拥有」，后续 fiber 静默回退（不报错、不重复 wiring）；typert 端点注册同理（重复注册失败时该 fiber 不提供端点）。首个获得 reviewer 角色的 apply 负责 observer / runtime / delivery 与 `/advisor` 指令的 wiring（单评审者守卫，`src/index.ts` `claimReviewer`），后续实例仅做 settings 注册尝试。**生命周期**：所有注册都是 fiber 作用域 effect —— fiber dispose 后端点 / 命名空间 / reviewer 声明随之撤销，后续 re-apply / re-mount 可接管。
+
+## 客户端入口（`dsh-advisor/client`）
+
+`src/client/index.ts` 是浏览器半，把 Advisor 卡片注册进宿主声明的 `settings.plugin.item` 卡片 slot（"插件配置"页，`id advisor`，order 30，位于上游 bash / agent-loop / web-search 卡片之后）：
+
+```ts
+import type { AdvisorCardProps, AdvisorSettingsStore, ModelOption, ProviderOption } from 'dsh-advisor/client'
+```
+
+- **`inject`**：`['slots', 'locale', 'connection']`（cordis fiber 注入）；locale 字典命名空间 `settings.advisor`（zh / en）；
+- **类型导出**：`AdvisorCardInjected`、`AdvisorCardProps`、`AdvisorKey`、`AdvisorDraft`、`AdvisorSettingsState`、`AdvisorSettingsStore`、`ApplyFailure`、`ApplyState`、`ModelOption`、`ModelsEmptyReason`、`ProviderOption`；
+- **value 导出**：`refreshIfLoaded`（纯 controller 辅助：仅在卡片首次加载后重取页面快照；未打开的卡片不在后台失效时发起 fetch）；
+- **web 注入声明**（`package.json` `dsh.client`）：`@deepseek-ai/dsh-client-runtime` + `@deepseek-ai/dsh-client-ui-settings-plugins` + `@deepseek-ai/dsh-client-locale`，平台 `web`；
+- **导入纯度边界**：客户端 half 只 value-import 冻结的平台模块表（`CLIENT_EXTERNALS`：react / `@deepseek-ai/cordis` / ui-slots / web-react / ui-primitives / schema-form / `@deepseek-ai/dsh-client-runtime/client`）；其余 `@deepseek-ai/*` 全部 type-only（构建期擦除），值经 cordis 注入到达。
+
+卡片的数据面（`src/client/advisor-store.ts`）：
+
+- **advisor 配置**：只经网关 RPC 通道（`connection.rpc.call('/api', 'advisor/get' | 'advisor/set', …)`）；`get` 返回 `{ config }`（宿主硬门禁后的 resolved 值，缺省键在 wire 上省略），`set` 接受 `{ patch }` 并返回新合成值；
+- **provider / model 目录**：走 `api.settings.describe` / `api.llm.*`（`llm-*` 命名空间在 exposed 集合内）；configured provider = 命名空间 + profile 均解析（KD-S2），model 选项 = profile 声明模型优先、catalog 回退；
+- 保存时对草稿与上次读取的配置做 diff，只发送变更键为 patch；清空 provider/model 存显式 `''`（网关 merge 无法表达 unset，解析器把 `''` 当缺失）；`advisor.get` 失败 → 卡片显示 config-channel 提示而非可写表单（KD-G5），永不提供 Apply。
+
+## `/advisor` 指令面
+
+`/advisor` 指令在组合了 command registry（`commands` 服务）时经条件 `ctx.inject(['commands'], ...)` 子项注册（`src/commands.ts` `registerAdvisorCommands`）—— 无 registry 的 headless / standalone 组合静默不注册。解析器 `parseAdvisorCommand`（`src/commands.ts`）接受恰好五种形式：
+
+```
+/advisor            toggle the advisor for this session
+/advisor on         enable the advisor for this session
+/advisor off        disable the advisor for this session
+/advisor status     show state, model, runtime status, pending count, last activity
+（其它输入）        → usage 文本
+```
+
+- **会话级且临时**：`on` / `off` / `toggle` 翻转的是按会话的 override（`AdvisorSessionOverrides`，`override ?? config.enabled`），**从不修改持久化配置**；`/advisor on` 开启一个 config 缺少 `provider`/`model` 的会话不会发起模型调用 —— 回复与 `/advisor status` 都会显示 S4 门禁原因；
+- **`/advisor on` 是手动恢复路径**：恢复 `quota_exhausted`（KD-5 无自动恢复定时器）并**全新重建** `halted`（永久性模型错误）的会话 runtime；开启时把 observer 游标 seed 到当前 transcript 长度（KD-5 seed-on-enable，不做全史重放）；
+- **`/advisor status`** 状态面（`src/commands.ts` `AdvisorSessionStatus` + `advisorStatusText`）：`enabled`（有效开关）、`disabledReason`（S4 门禁阻挡时）、`provider` / `model`（即使禁用也显示）、`runtimeStatus`（`running` | `paused` | `quota_exhausted` | `halted` | `disabled`）、`pendingCount`（待 drain 的 delta 数）、`lastActivityAt`（最后一次 accepted-note 的 ISO 时间，之前为 `never`）。
+
+## 安装 / 发布指针
+
+- [安装指南](install.zh.md) — registry / 本地目录 / tarball 三种安装方式、web Settings 暴露、`--dump-config` 验证、卸载；
+- [发布指南](release.md) — PR 驱动的 npm 发布与 GitHub Release 流程、版本策略、回滚；
+- [配置指南](configuration.md) — `advisor` 命名空间字段、显式模型门禁、行为要点；
+- [README](../README.zh.md) — 概览、配置示例、`/advisor` 用法、工作原理、限制与路线图。

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -1,0 +1,98 @@
+# 验证记录（测试矩阵与真实环境验证）
+
+本文记录 `dsh-advisor` 已完成的验证证据（**本仓库 workspace 内可完成的**：单测 / 集成 / 客户端组件 / 网关 / 指令 / 发布工具链测试 + typecheck + build + CI 契约），以及**必须在用户真实 dsh 环境执行**的验证步骤与预期。
+
+> **范围声明**：本仓库的验证环境受沙箱约束 —— **不能对运行中的 dsh 安装（真实 `$DSH_HOME`）做任何写入**，不能操作 web Settings GUI、不能发起真实模型调用、不能跨进程观察真实会话。因此下方「已验证」只覆盖 workspace 内可完成的证据（测试套件、typecheck、build、CI 工作流契约）；「待用户运行」如实列出真实环境步骤与预期，不夸大已验证范围。验证数据采集于分支 `docs/align-docs-triplet`（base `origin/main` @ `c07827e`），vitest 3.2.7。
+
+## 已验证（workspace 内证据）
+
+### 1. 测试矩阵（16 个文件 / 319 个用例，全部通过）
+
+`pnpm run test`（vitest run）输出：**Test Files 16 passed (16) / Tests 319 passed (319)**。逐文件用例数从该次运行的 verbose 输出统计（各文件 `describe` 块覆盖契约如下）：
+
+| 测试文件 | 用例数 | 覆盖契约 |
+|---|---|---|
+| `advisor-card.spec.tsx` | 30 | Advisor 卡片：`settings.plugin.item` 注册（不污染 `settings.section`）；上游 PluginCard chrome（默认折叠 / aria-expanded / unsaved pill / Save-Discard 启停）；网关通道读写（`advisor/get` 读配置、`advisor/set` 保存、wire 失败提示、重试）；enabled 开关 + 必填 provider/model 门禁文案；只列已配置 provider；存储值不再可用时的警告；read-only provider 提示；网关不可达时不提供 Save；zh/en 文案 |
+| `advisor-runtime.test.ts` | 27 | 每 delta 一次 `llm.stream` 调用与选项；`extractAdviceNote` JSON-frame 解析（KD-2，容忍 prose/fence、severity 缺省 nit）；failure policy（KD-5：transient 1 次重试→drop、连续 3 次 drop 冲刷 backlog、quota→暂停保留批次、permanent→halt）；60s 调用 deadline 超时；dispose 中止在途调用；对真实 `LlmRuntime` + 注册 adapter 的选项下发；`reasoningEffort` 能力门控（无推理元数据的 adapter 不发送） |
+| `advisor-store.test.ts` | 51 | store：providers join（KD-S2 configured 判定）；model options（profile 优先、catalog 回退）；apply gate（KD-S4 enabled 必填）；apply patch + seed（只写变更键、清空字段存显式 `''`）；invalidations（`refreshIfLoaded`）；gateway availability（KD-G5 `advisorPresent`）；post-apply reload 失败保留反馈（qc3 N-1）；discard 回滚草稿；dirty 派生（KD-U2）；read-only apply guard（qc2 W-1）；卡片场景（load → edit → apply → discard 往返） |
+| `client-build.test.ts` | 7 | 客户端 bundle 契约（`scripts/build-client.mjs`）：构建 `lib/client.js` + `lib/client.d.ts`；closure-factory load handoff；classic-script 安全（无 `import.meta` / 顶层 ESM）；`CLIENT_EXTERNALS` 纯度边界；automatic JSX runtime；CSS Modules 内联；`dsh.client` 声明 |
+| `commands.test.ts` | 22 | `parseAdvisorCommand`（空 → toggle，on/off/status 精确匹配，其它 → usage）；`AdvisorSessionOverrides`（`override ?? config.enabled`）；`registerAdvisorCommands` 注册形态（name/description/hint/handler + disposer）；handler toggle/on/off 翻转 runtime gate（含 already-on、S4 gate caveat 文案）；`advisorStatusText` 状态面；未知子命令 → usage 且不触碰 controller |
+| `config.test.ts` | 19 | Loader schema 默认值（`Config({})` = 全默认）；显式模型门禁 S4（缺省禁用无 reason、enabled-without-pair → disabled-with-reason、全空白字符串视为空）；未知键严格拒绝（禁用与启用两种状态） |
+| `delivery.test.ts` | 17 | 严重度 → 通道路由（nit→inject 非唤醒、concern/blocker→steer 唤醒）；advisor 消息构造（user-role + advisor source kind + 自描述内容 + 有界 summary）；`immuneTurns` 冷却（窗口内降级 inject、倒计时耗尽再 steer、仅在真实 steer 后武装、`reset`/`unregisterAgent` 清栅栏）；缺 agent → drop + 日志（KD-4）；route 内 throw 被 containment（T4 F1）；`SessionTranscriptObserver` delivery hooks（每个 stepped 可评审 turn/end 触发一次、跳过 no-step 与 aborted） |
+| `emission-guard.test.ts` | 20 | 归一化（等价拼写同一身份）；content-free 短语抑制（stop/done/complete/no issue continue/lgtm/nothing to add）；跨 update 去重；每次 update 至多一条 note；升级放行（nit→concern→blocker）；FIFO 有界历史（默认 4096）；`reset` 清状态；`createEmissionGuard` 工厂；runtime 接线（只对 accepted note 调 delivery 回调、被抑制的 note 继续 drain、throwing guard 被 containment） |
+| `gateway.test.ts` | 22 | 无 settings service（entry fallback，`get` 可用，gateway 是已注册服务）；有 settings service（`set` 写 user layer、合成值 live 变化、`set` 返回新合成值、merge 语义、空/null patch 为 no-op）；`set` 校验（未知键在写入前被拒）；硬门禁回归（`resolveAdvisorConfig` 保持 SSOT）；typertGateway 端点认领 + payload 契约（`{ args }` 恰好一个 plain-object 字段、`/api` interceptor 分发、直接经 `ctx.typertGateway` 调用、bad user layer 的 get containment）；组合插件（apply wiring 后 dispatch 对 live 合成配置生效、多 fiber 去重） |
+| `integration.test.ts` | 19 | 完整 advisor 循环（user → primary → turn/end → delta → advisor call → guard → steer，stub adapter，spec §7）；agentic reply-complete 门驱动循环（nit→inject / concern→steer、immuneTurns 栅栏衰减，KD-N4-5）；自送达不重触发评审门（C-1）；`/advisor` 指令条件激活（无 registry 全周期、组合后注册、on 启动 live runtime + KD-5 seed）；compact / surface-replace 重置组合 observer + guard（KD-5）；`/advisor` 恢复 + S4 gate 报告（quota 暂停手动恢复、halted 全新重建、config-enabled-but-gate-blocked 的 status/on 文案）；root-llm 从隔离子作用域解析（qc1 W-3）；单评审者守卫（n4 QC F-6：第二个 apply 不接第二个 reviewer、dispose 释放声明、被拒 config 不占声明） |
+| `peer-deps.test.ts` | 6 | registry peer 契约：每个 `@deepseek-ai/*` 都是 peerDependency 且不出现在其它 dependency 字段、`dsh-*` 钉在 `^0.1.0-rc.6`、无 link farm（从 npm 解析） |
+| `prepare-release.test.ts` | 20 | 发布准备脚本（`scripts/prepare-release.mjs`）：auto patch bump（正式版 / prerelease 线自增）、显式版本（含 prerelease）、非法版本拒绝、空版本范围拒绝、已有 tag 拒绝、`CHANGELOG.md` 小节写入（header 存在性 / 无尾换行 / 0 字节 / 纯空白 / 重复运行 no-op / 祖先 tag 范围） |
+| `scaffold.test.ts` | 2 | bundle 清单契约（T1）：非 private 可打包、声明 `dsh.bundle` patch 与 advisor 行（`cordis.patch.yml`） |
+| `settings-live.test.ts` | 8 | settings live 重应用：latched config + runtime rebuild（改 provider/model/systemPrompt 重建、immuneTurns 原地更新）；observer `maxDeltaMessages` 应用到已 live 的 per-session renderer；硬门禁穿透 live source（禁用仍阻止 runtime 创建、无 pair 再启用仍被门禁）；条件 runtime rebuild（qc3 W-1 / qc1 W-2：只改 immuneTurns 不重建、backlog 与 emission guard 存活）；未知键 user layer containment（qc2 W-1：不 wedge、无模型调用、status 显示 disabled-with-reason）；attach ordering + detach fallback（qc1 S-1 / qc3 S-2） |
+| `settings.test.ts` | 13 | 无 settings service（entry fallback，行为与今日一致）；命名空间注册（`describe` 暴露 ns / `Config` schema / base / live 值；多 fiber 去重只注册一次）；user-layer 写入（schema 默认 → base → user 合成、source thunk live 反映）；硬门禁回归（settings 写入的 enabled-without-pair 仍解析 disabled-with-reason）；未知键严格拒绝不变 |
+| `transcript.test.ts` | 36 | `DeltaRenderer`：append 游标推进；前缀重写检测（指纹不匹配 → 重置全量重放）；compact 事件重放（KD-5）；自审排除（advisor-source 消息不进 delta）；有界窗口（`maxDeltaMessages` 截断标记）；markdown 渲染（tool calls / tool results）；`seedTo`（KD-5）；`SessionTranscriptObserver`：agentic reply-complete 门（每次 human-input 到达恰一条 delta、trigger 排除）；inbox 拼接 payload 判别（C-1）；wiring（turn 检测 + per-session 分发） |
+| **合计** | **319** | 16 个文件 / 319 个用例全部通过（`pnpm run test`，vitest 3.2.7） |
+
+### 2. typecheck / build
+
+- `pnpm run typecheck`（`tsc --noEmit` + `tsc -p tsconfig.client.json --noEmit` + `tsc -p tsconfig.spec.json --noEmit`）—— **通过**（本文档改动不含代码变更，typecheck 为回归确认）；
+- `pnpm run build`（`tsc -p tsconfig.build.json` + `scripts/build-client.mjs` → `lib/client.js` + `lib/client.d.ts`）—— **通过**。
+
+### 3. CI 契约（`.github/workflows/ci.yml`）
+
+CI 在 PR 与 `main` push 上运行：`pnpm install --frozen-lockfile` → `pnpm run typecheck` → `pnpm run build` → `pnpm run test` → `npm pack --dry-run` 内容断言（`lib/index.js` 与 `cordis.patch.yml` 必须在 tarball 列表内）。发布链（Release prep / Release 工作流）见 [docs/release.md](release.md)。
+
+## 真实环境待验证步骤（由用户在真实 dsh 环境执行）
+
+> 以下步骤必须在**真实 dsh 环境**执行（可写 `$DSH_HOME` 安装、可操作的 web GUI、能发起真实模型调用）；路径一律以 `$DSH_HOME` 表达，不用本地绝对路径。步骤与预期来自 [docs/install.zh.md](install.zh.md)（§1–§6）与 `docs/configuration.md` 的行为要点，逐项对照。
+
+### 1. 安装与 profile 验证
+
+```sh
+cd <plugin-repo>
+pnpm install          # 构建组合包（prepare 自建）
+dsh plugin --profile web add .   # <name> = 你的 profile 名
+dsh --profile web --dump-config   # 应出现 "# == dsh-advisor" 层与 advisor 行
+dsh --profile web                  # 重启 dsh 会话使宿主半与客户端半加载
+```
+
+**预期**：`dsh.profile.bundles` 追加本插件（`add` 默认追加到末尾）；`--dump-config` 输出含 `# == dsh-advisor` 层与 `id: advisor` 行（`name: dsh-advisor`）。
+
+### 2. web 插件配置卡片验证
+
+1. 打开 web Settings → **"插件配置"**页，确认 **Advisor 卡片**出现（与 bash / agent-loop / web-search 卡片同列，位于其后）。
+2. **首次打开（无 `advisor` 配置）**：卡片渲染头部 + enabled 开关（默认 **OFF**）+ 表单（enabled 关闭时表单体隐藏、显示提示）。
+3. 打开 `enabled` 开关 → 出现 provider / model 选择框（**只列出已配置的 provider** 及其模型）、`systemPrompt` 文本框（placeholder 提示空 = 默认）与 `immuneTurns` / `maxDeltaMessages` 数字输入。
+4. 选择 provider/model 并保存 → **预期**：保存成功（经 `/api/advisor/set`）；`$DSH_HOME/settings.yaml`（或该 profile 的 settings 路径）写入 `advisor:` 段（含 `enabled: true` 与所选 provider/model）；重进页面显示已保存值。
+5. 降级路径抽查：网关不可达时卡片显示 config-channel 提示且不提供 Save；settings provider 只读时显示只读提示并禁用写入；`advisor.get` 失败时头部显示可重试的加载失败提示。
+6. **S4 门禁**：`enabled: true` 而 provider/model 为空时保存被阻止（卡片侧文案）；手工在 YAML 写 enabled-without-pair 后重进页面，卡片显示门禁后的值，且宿主侧绝不发起模型调用（日志无 advisor 模型调用）。
+
+### 3. `/advisor` 指令验证（真实会话内）
+
+1. 在任意会话输入 `/advisor status` → **预期**：输出 `Advisor: enabled/disabled`、门禁原因（如适用）、`Model: <provider>/<model>`、`Runtime: <running|paused|quota_exhausted|halted|disabled> (N pending)`、`Last activity: <ISO|never>`。
+2. `/advisor on` / `/advisor off` / 裸 `/advisor`（toggle）→ **预期**：翻转会话级状态、回复带 S4 caveat（当门禁阻挡）；`settings.yaml` **不变**（指令是临时 override，不写持久化配置）。
+3. 未知子命令（如 `/advisor foo`）→ usage 文本。
+4. 恢复路径：制造 quota/rate-limit 暂停（`quota_exhausted`）后 `/advisor on` 原地恢复；制造永久性模型错误（`halted`）后 `/advisor on` 为该会话全新重建 —— 两者都无需重启宿主。
+
+### 4. 运行时行为验证（真实模型调用）
+
+1. 配置 enabled + provider/model，发起一次会话并完成若干 stepped 主 turn。
+2. **预期**：每个可评审 turn/end 之后日志出现一次 advisor 模型调用（`ctx.llm.stream`，`maxTokens 5120`）；抽取出的 note 以 `[advisor:{severity}] <note>` 出现在会话流（nit → 非唤醒注入；concern/blocker → steer 唤醒）；advisor 自己的消息不进入后续 advisor delta（自审排除）。
+3. **immuneTurns 冷却**：连续产生 concern/blocker 时，前一条实际 steer 后接下来的 `immuneTurns` 个主 turn 内，打断性 note 降级为 inject。
+4. **failure policy 抽查**：配置不可用的模型（如不存在/无效凭据）→ 日志出现 transient drop（或 permanent halt）；halted 后该会话 advisor 停止，`/advisor on` 重建。
+
+### 5. 卸载验证
+
+```sh
+dsh plugin --profile web remove dsh-advisor
+dsh --profile web --dump-config   # 确认 dsh-advisor 层已消失
+```
+
+## 已知限制（沙箱无法覆盖的真实运行时表面）
+
+| 表面 | 为何未覆盖 | 验证归属 |
+|---|---|---|
+| web Settings GUI 交互（卡片出现、编辑保存、降级态） | 沙箱无法操作真实 web 会话 | 用户 §2（客户端 half 逻辑已由 `advisor-card.spec.tsx` 30 例 + `advisor-store.test.ts` 51 例覆盖） |
+| 真实模型调用与 failure 注入（quota / permanent / 超时） | 沙箱没有真实模型凭据与运行中会话 | 用户 §4（决策逻辑已由 `advisor-runtime.test.ts` / `integration.test.ts` 覆盖） |
+| 跨进程观察（日志、会话流中的 `[advisor:…]` 注入、真实 session/event 流） | 沙箱无法运行真实 dsh 会话 | 用户 §3/§4 |
+| `/advisor` 在真实会话的输入/输出 | 沙箱无法运行真实 dsh 会话与 command registry | 用户 §3（指令逻辑已由 `commands.test.ts` 22 例 + `integration.test.ts` 的 T7 用例覆盖） |
+| 写入真实 `$DSH_HOME` / `settings.yaml` | 沙箱禁止对运行中 dsh 安装写入 | 用户 §1/§2/§5（settings/gateway 写入逻辑已由 `settings.test.ts` / `gateway.test.ts` / `settings-live.test.ts` 覆盖） |
+
+任何与上述预期不符的步骤 → 记录为 QA finding（严重度 + 复现步骤），如实上报，不写回「已验证」。


### PR DESCRIPTION
## What

Completes the top-level docs area (user-named alignment with sibling dsh-llm-fallbacks): three new docs, sibling structure but fully advisor-accurate.

- **docs/configuration.md**: advisor settings namespace, field table (enabled/provider/model/systemPrompt/immuneTurns/maxDeltaMessages from src/config.ts), S4 gate, severity→channel semantics, immuneTurns cooldown
- **docs/consumer-api.md**: package-root exports (name/inject/Config/apply — honestly no function-granular re-exports), client entry (settings.plugin.item card), /advisor commands
- **docs/verification.md**: real test matrix (16 files / 319 tests, per-file counts from pnpm test output), honest sandbox scope + real-env steps

Deliberate omissions (no dsh-advisor analog): reset endpoint, reset-to-defaults, two-block model. No verbatim porting; every claim anchored in source.

## Checks

- pnpm test 319/319, typecheck + build green