### PR TITLE
release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to dsh-advisor are documented here. Generated from git log by the release-prep workflow.
 
+## [0.1.3] - 2026-08-15
+
+- 17f544a Merge pull request #47 from omdsh-dev/docs/align-docs-triplet
+- c07827e Merge pull request #46 from omdsh-dev/docs/align-topdocs-ci
+- cf34eec Merge pull request #45 from omdsh-dev/fix/release-final-align
+
 ## [0.1.3-alpha.5] - 2026-08-15
 
 - 79a07f2 Merge pull request #43 from omdsh-dev/fix/release-crosscheck

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-advisor",
-  "version": "0.1.3-alpha.5",
+  "version": "0.1.3",
   "type": "module",
   "description": "dsh plugin bundle porting the omp advisor subsystem: a per-session reviewer model that observes the primary transcript and injects severity-ranked advice (nit/concern/blocker).",
   "repository": {


### PR DESCRIPTION
## [0.1.3] - 2026-08-15

- 17f544a Merge pull request #47 from omdsh-dev/docs/align-docs-triplet
- c07827e Merge pull request #46 from omdsh-dev/docs/align-topdocs-ci
- cf34eec Merge pull request #45 from omdsh-dev/fix/release-final-align


Merging this PR tags v0.1.3 and publishes dsh-advisor@0.1.3 via the Release workflow.
