### PR TITLE
docs(readme): add dshfind badges (en + zh)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ English | [中文](README.zh.md)
 [![license](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 ![node](https://img.shields.io/badge/node-%5E22.19%20%7C%7C%20%3E%3D24-339933.svg)
 ![dsh](https://img.shields.io/badge/dsh-DeepSeek%20Harness%20compatible-4B32C3.svg)
+[![dshfind](https://dshfind.com/api/badge/omdsh-dev/dsh-advisor)](https://dshfind.com/plugins/omdsh-dev/dsh-advisor?ref=badge)
 
 A standalone dsh plugin bundle porting the omp "advisor"
 subsystem: a per-session reviewer model that observes the primary transcript,

--- a/README.zh.md
+++ b/README.zh.md
@@ -5,6 +5,7 @@
 [![license](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 ![node](https://img.shields.io/badge/node-%5E22.19%20%7C%7C%20%3E%3D24-339933.svg)
 ![dsh](https://img.shields.io/badge/dsh-DeepSeek%20Harness%20compatible-4B32C3.svg)
+[![dshfind](https://dshfind.com/api/badge/omdsh-dev/dsh-advisor?lang=zh)](https://dshfind.com/zh/plugins/omdsh-dev/dsh-advisor?ref=badge)
 
 一个移植 omp「advisor」子系统的独立 dsh 插件组合包：一个按会话运行的评审模型，观察主会话 transcript，用显式配置的模型（provider 与 model 均为必填）评审每个已完成的 stepped turn，并把按严重度排序的建议（nit / concern / blocker）注入回会话 —— 不污染主循环，也不递归地评审自己。
 


### PR DESCRIPTION
Adds the dshfind badge to both READMEs.

- `README.zh.md`: `…?lang=zh` badge → `/zh/plugins/…?ref=badge` (as provided)
- `README.md`: language-neutral badge → `/plugins/…?ref=badge`

All four URLs probed: badge endpoints return `200 image/svg+xml`, pages return `200 text/html`.

Trivial docs-only commit — rides the next substantive release per repo release policy.