### PR TITLE
release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to dsh-advisor are documented here. Generated from git log by the release-prep workflow.
 
+## [0.2.0] - 2026-08-16
+
+- 9984fd5 feat(advisor): dsh-tui client surface — tuiCommandTrees /advisor + /advisor config readback + docs (#53)
+
 ## [0.1.4] - 2026-08-15
 
 - 8ec21db fix: audit wave 2026-08-15 — docs align, backlog tests, card invalidation, fingerprint verdict (#51)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-advisor",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "type": "module",
   "description": "dsh plugin bundle porting the omp advisor subsystem: a per-session reviewer model that observes the primary transcript and injects severity-ranked advice (nit/concern/blocker).",
   "repository": {


### PR DESCRIPTION
## [0.2.0] - 2026-08-16

- 9984fd5 feat(advisor): dsh-tui client surface — tuiCommandTrees /advisor + /advisor config readback + docs (#53)


Merging this PR tags v0.2.0 and publishes dsh-advisor@0.2.0 via the Release workflow.
