### PR TITLE
release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to dsh-advisor are documented here. Generated from git log by the release-prep workflow.
 
+## [0.2.1] - 2026-08-17
+
+- b1f3e6d feat(advisor): TUI settings write surface — tuiSettingsSections Advisor section (dsh-tui /settings) (#56)
+- f88c4fb chore: ignore .mstar process artifacts + .worktrees (canonical harness ignore) (#55)
+
 ## [0.2.0] - 2026-08-16
 
 - 9984fd5 feat(advisor): dsh-tui client surface — tuiCommandTrees /advisor + /advisor config readback + docs (#53)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-advisor",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "description": "dsh plugin bundle porting the omp advisor subsystem: a per-session reviewer model that observes the primary transcript and injects severity-ranked advice (nit/concern/blocker).",
   "repository": {


### PR DESCRIPTION
## [0.2.1] - 2026-08-17

- b1f3e6d feat(advisor): TUI settings write surface — tuiSettingsSections Advisor section (dsh-tui /settings) (#56)
- f88c4fb chore: ignore .mstar process artifacts + .worktrees (canonical harness ignore) (#55)


Merging this PR tags v0.2.1 and publishes dsh-advisor@0.2.1 via the Release workflow.
