### PR TITLE
release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to dsh-advisor are documented here. Generated from git log by the release-prep workflow.
 
+## [0.2.2] - 2026-08-17
+
+- 50d9e38 fix(client): rc.7 keyed settings.plugin.item + dsh peer floor (#59)
+
 ## [0.2.1] - 2026-08-17
 
 - b1f3e6d feat(advisor): TUI settings write surface — tuiSettingsSections Advisor section (dsh-tui /settings) (#56)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-advisor",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "description": "dsh plugin bundle porting the omp advisor subsystem: a per-session reviewer model that observes the primary transcript and injects severity-ranked advice (nit/concern/blocker).",
   "repository": {


### PR DESCRIPTION
## [0.2.2] - 2026-08-17

- 50d9e38 fix(client): rc.7 keyed settings.plugin.item + dsh peer floor (#59)


Merging this PR tags v0.2.2 and publishes dsh-advisor@0.2.2 via the Release workflow.
