### PR TITLE
release v0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to dsh-advisor are documented here. Generated from git log by the release-prep workflow.
 
+## [0.2.4] - 2026-08-21
+
+- 2c08ef9 feat: upgrade dsh peers to 0.1.1-rc.1 (#64)
+
 ## [0.2.3] - 2026-08-20
 
 - 264038b docs: badge the DSH compatible version 0.1.0-rc.8 (#62)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-advisor",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "type": "module",
   "description": "dsh plugin bundle porting the omp advisor subsystem: a per-session reviewer model that observes the primary transcript and injects severity-ranked advice (nit/concern/blocker).",
   "repository": {


### PR DESCRIPTION
## [0.2.4] - 2026-08-21

- 2c08ef9 feat: upgrade dsh peers to 0.1.1-rc.1 (#64)


Merging this PR tags v0.2.4 and publishes dsh-advisor@0.2.4 via the Release workflow.
