### PR TITLE
fix(client): declare dotted remote namespace injects (dsh 0.1.2-rc.1)

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -73,8 +73,17 @@ export { refreshIfLoaded } from './advisor-store.ts'
  * Required services (cordis fiber inject). The target slot is declared by
  * ui-plugin-config's apply, whose activation order relative to this one is
  * NOT constrained; registration depends on the slot through `slots.inject()`.
+ *
+ * rc.1 dotted-namespace contract: each client Remote namespace is a
+ * child-fiber service named `remote.<ns>` (upstream `remoteServiceKey`), and
+ * the traceable proxy forwards `ctx.remote.llm` / `.settings` / `.session`
+ * to those context properties — consumers MUST declare the dotted names
+ * here or the fiber walk throws `cannot get property "remote.llm" without
+ * inject`. `remote` stays for the `$on` invalidation face; `connection` for
+ * the `connection.rpc` gateway channel. Reference shape:
+ * ../deepseek-harness/packages/client/ui-settings-models/src/client/index.ts.
  */
-export const inject = ['slots', 'locale', 'connection', 'settingsSchema', 'remote']
+export const inject = ['slots', 'locale', 'connection', 'settingsSchema', 'remote', 'remote.llm', 'remote.settings', 'remote.session']
 
 /**
  * Register the Advisor card once the `settings.plugin.item` declaration is on
@@ -89,7 +98,9 @@ export function apply(ctx: ClientContext): void {
   // The store reads/writes the advisor config over the connection's generic
   // RPC channel (the host gateway `/api/advisor/get` + `/api/advisor/set`);
   // the provider/model directory rides the client Remote assembly (`remote`
-  // — injected above; KD-G3, alpha.2).
+  // — injected above; KD-G3; the dotted `remote.llm` / `remote.settings` /
+  // `remote.session` namespaces are declared in `inject` per the rc.1
+  // dotted-namespace contract).
   const controller = new AdvisorSettingsStore(ctx.remote, connection.rpc, ctx.settingsSchema)
 
   // Pushed invalidations converge the open surface without polling. Two
@@ -109,9 +120,11 @@ export function apply(ctx: ClientContext): void {
   //   vocabulary; the forwarded-event allowlist is their replacement (plan
   //   003 / status R3 — restores same-host live convergence without a
   //   reconnect).
-  // `remote` is injected above (alpha.2: the client Remote assembly is the
-  // store's provider-directory wire, so it is a hard registration
-  // dependency). A burst of invalidations coalesces into a single refetch via
+  // `remote` is injected above (the client Remote assembly is the store's
+  // provider-directory wire, so it is a hard registration dependency; its
+  // dotted namespace services `remote.llm` / `remote.settings` /
+  // `remote.session` are declared in `inject` — rc.1 dotted-namespace
+  // contract). A burst of invalidations coalesces into a single refetch via
   // the microtask debounce — events in separate ticks each trigger a load,
   // and `refreshIfLoaded` keeps an unopened card idle.
   ctx.effect(() => {

--- a/tests/advisor-card.spec.tsx
+++ b/tests/advisor-card.spec.tsx
@@ -53,7 +53,7 @@ import { AdvisorCard } from '../src/client/advisor-card'
 import type { AdvisorCardProps } from '../src/client/advisor-card'
 import { AdvisorSettingsStore, refreshIfLoaded } from '../src/client/advisor-store'
 import type { AdvisorConfigView, AdvisorSettingsState, AdvisorStoreRemote } from '../src/client/advisor-store'
-import { apply } from '../src/client/index'
+import { apply, inject } from '../src/client/index'
 import { en, zh } from '../src/client/locales'
 
 afterEach(cleanup)
@@ -249,16 +249,25 @@ function fakeRuntime(scripted: Scripted) {
   const locales: Record<string, unknown> = {}
   const resetHandlers = new Set<() => void>()
   const remoteHandlers: Record<string, Set<() => void>> = {}
+  // The generated namespace surface (rc.1 dotted contract): each Remote
+  // namespace is a child-fiber service named `remote.<ns>` (upstream
+  // `remoteServiceKey`), so the fixture provides them as separate dotted
+  // services — the declared injects resolve exactly like production. The
+  // assembly face forwards `remote.llm` etc. to the dotted services (mirror
+  // of the traceable proxy: `ctx.remote.llm` → `ctx['remote.llm']`).
+  const services: Record<string, unknown> = {
+    'remote.llm': { listConfigurableProviders: scripted.listConfigurableProviders },
+    'remote.settings': { describe: scripted.describe },
+    'remote.session': { modelCatalog: scripted.modelCatalog },
+  }
   const remote = {
     $on: (event: string, handler: () => void): (() => void) => {
       ;(remoteHandlers[event] ??= new Set()).add(handler)
       return () => { remoteHandlers[event]?.delete(handler) }
     },
-    // The generated namespace surface the store reads its provider directory
-    // from (alpha.2): wired to the same scripted fakes as the store tests.
-    llm: { listConfigurableProviders: scripted.listConfigurableProviders },
-    settings: { describe: scripted.describe },
-    session: { modelCatalog: scripted.modelCatalog },
+    get llm() { return services['remote.llm'] },
+    get settings() { return services['remote.settings'] },
+    get session() { return services['remote.session'] },
   }
   const slots = {
     register: (options: Record<string, unknown>, component: unknown): (() => void) => {
@@ -287,7 +296,7 @@ function fakeRuntime(scripted: Scripted) {
     },
     get: (key: string): unknown => {
       if (key === 'connection') return { rpc: scripted.rpc }
-      return undefined
+      return services[key]
     },
     effect: (fn: () => unknown): (() => void) => {
       const disposer = fn()
@@ -309,6 +318,17 @@ function fakeRuntime(scripted: Scripted) {
 }
 
 describe('AdvisorCard registration (settings.plugin.item)', () => {
+  it('declares the dotted remote namespace injects (rc.1 contract)', () => {
+    // Regression pin (upstream apply.client.spec.ts asserts the array
+    // literally): each client Remote namespace is a child-fiber service
+    // named `remote.<ns>`; without the dotted names the fiber walk throws
+    // `cannot get property "remote.llm" without inject` at card load.
+    expect(inject).toEqual([
+      'slots', 'locale', 'connection', 'settingsSchema', 'remote',
+      'remote.llm', 'remote.settings', 'remote.session',
+    ])
+  })
+
   it('registers the advisor card and leaves no advisor entry in settings.section', () => {
     const scripted = scriptedApi()
     const { ctx, ledger, locales } = fakeRuntime(scripted)


### PR DESCRIPTION
## Problem

dsh@next (0.1.2-rc.1) + advisor v0.3.0: after boot, loading the advisor config on the web 插件配置 page throws `cannot get property "remote.llm" without inject` — the card never loads its provider/model directory.

## Root cause

Upstream dsh commit `5b2f679e4a` (refactor(client): consume migrated Remote namespaces, shipped by 0.1.2-alpha.2) split the client Remote assembly into **dotted per-namespace services** (`remote.llm`, `remote.settings`, `remote.session`, … — child-fiber services named `remote.<ns>`). Consumers must declare the dotted names in their cordis `inject`; reading `ctx.remote.llm` forwards through the traceable proxy to a context property read of `remote.llm`, and the fiber walk only resolves it when the consuming plugin declares the dotted name. The advisor client still declared `['slots','locale','connection','settingsSchema','remote']` from the alpha.2 era → fiber walk hit the root and threw.

The unit fixture stubbed `remote` as a plain object, so the real resolution path was never exercised (same blind spot as harness postmortem 0001).

## Fix

- `src/client/index.ts`: `inject` → `['slots','locale','connection','settingsSchema','remote','remote.llm','remote.settings','remote.session']`; stale alpha.2 comments updated to the rc.1 dotted-namespace contract.
- `tests/advisor-card.spec.tsx`: fixture provides the dotted services (mirroring upstream spec fixtures); literal inject-shape contract assertion added (fails if any dotted name is dropped — verified by temporary removal during dev).

## Verification

- `pnpm typecheck` / `pnpm build` / `pnpm test` green (18 files, 377 tests).
- QC (single seat, inline hotfix): **Approve** — 0 critical / 0 warning (`.mstar` review bundle qc.md).
- QA (real surface, dsh 0.1.2-rc.1, web profile): **PASS** — advisor card loads with provider directory populated, zero `without inject` errors (browser-verified, screenshot in review bundle).

## Scope

Web profile only this round (dsh-tui/headless deferred by maintainer decision 2026-09-03; neither reads `remote.*`). Sibling note: `dsh-llm-fallbacks` (also mounted in the web profile) may need the same dotted-inject adaptation — out of scope here.