### PR TITLE
release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to dsh-advisor are documented here. Generated from git log by the release-prep workflow.
 
+## [0.3.1] - 2026-09-03
+
+- 058fa1b fix(client): declare dotted remote namespace injects (dsh 0.1.2-rc.1) (#76)
+
 ## [0.3.0] - 2026-09-03
 
 - 6ff3b0f chore(deps): upgrade dsh peers to 0.1.2-rc.1 (#74)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-advisor",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "description": "dsh plugin bundle porting the omp advisor subsystem: a per-session reviewer model that observes the primary transcript and injects severity-ranked advice (nit/concern/blocker).",
   "repository": {


### PR DESCRIPTION
## [0.3.1] - 2026-09-03

- 058fa1b fix(client): declare dotted remote namespace injects (dsh 0.1.2-rc.1) (#76)


Merging this PR tags v0.3.1 and publishes dsh-advisor@0.3.1 via the Release workflow.
