### PR TITLE
release v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to dsh-advisor are documented here. Generated from git log by the release-prep workflow.
 
+## [0.3.2] - 2026-09-10
+
+- 663ed6d chore(deps): 升级 dsh peers 到 0.1.5-rc.1 / upgrade dsh peers to 0.1.5-rc.1 (#79)
+
 ## [0.3.1] - 2026-09-03
 
 - 058fa1b fix(client): declare dotted remote namespace injects (dsh 0.1.2-rc.1) (#76)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-advisor",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "type": "module",
   "description": "dsh plugin bundle porting the omp advisor subsystem: a per-session reviewer model that observes the primary transcript and injects severity-ranked advice (nit/concern/blocker).",
   "repository": {


### PR DESCRIPTION
## [0.3.2] - 2026-09-10

- 663ed6d chore(deps): 升级 dsh peers 到 0.1.5-rc.1 / upgrade dsh peers to 0.1.5-rc.1 (#79)


Merging this PR tags v0.3.2 and publishes dsh-advisor@0.3.2 via the Release workflow.
