### PR TITLE
release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to dsh-advisor are documented here. Generated from git log by the release-prep workflow.
 
+## [0.4.1] - 2026-09-11
+
+- c681865 Merge pull request #85 from omdsh-dev/chore/dsh-0.1.5-rc.2
+
 ## [0.4.0] - 2026-09-10
 
 - a2cc44f Merge pull request #83 from omdsh-dev/chore/vitest-4.1.11

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-advisor",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "description": "dsh plugin bundle porting the omp advisor subsystem: a per-session reviewer model that observes the primary transcript and injects severity-ranked advice (nit/concern/blocker).",
   "repository": {


### PR DESCRIPTION
## [0.4.1] - 2026-09-11

- c681865 Merge pull request #85 from omdsh-dev/chore/dsh-0.1.5-rc.2


Merging this PR tags v0.4.1 and publishes dsh-advisor@0.4.1 via the Release workflow.
